### PR TITLE
Additional updates

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -215,7 +215,7 @@ jobs:
 
           set -x  # echo on
           $(command -v mamba || command -v conda) install -c nodefaults \
-            packaging pytest coverage pytest-randomly cffi donfig tomli c-compiler make \
+            packaging pip pytest coverage pytest-randomly cffi donfig tomli c-compiler make \
             pyyaml${yamlver} ${sparse} pandas${pdver} scipy${spver} numpy${npver} ${awkward} \
             networkx${nxver} ${numba} ${psg} \
             ${{ matrix.slowtask == 'pytest_bizarro' && 'black' || '' }} \
@@ -227,24 +227,26 @@ jobs:
             # ${{ matrix.os != 'windows-latest' && 'pytest-forked' || '' }}  # to investigate crashes
       - name: Build extension module
         run: |
+          # ``python -m pip`` ensures the conda env's interpreter drives the
+          # install, not a system ``pip`` on PATH.
           if [[ ${{ steps.sourcetype.outputs.selected }} == "wheel" ]]; then
               # Add --pre if installing a pre-release
-              pip install --no-deps --only-binary ":all:" suitesparse-graphblas${psgver}
+              python -m pip install --no-deps --only-binary ":all:" suitesparse-graphblas${psgver}
 
               # Add the below line to the conda install command above if installing from test.pypi.org
               # ${{ steps.sourcetype.outputs.selected == 'wheel' && 'setuptools setuptools-git-versioning wheel cython' || '' }} \
-              # pip install --no-deps --only-binary ":all:" --index-url https://test.pypi.org/simple/ "suitesparse-graphblas>=7.4.3"
+              # python -m pip install --no-deps --only-binary ":all:" --index-url https://test.pypi.org/simple/ "suitesparse-graphblas>=7.4.3"
           elif [[ ${{ steps.sourcetype.outputs.selected }} == "source" ]]; then
               # Add --pre if installing a pre-release
-              pip install --no-deps --no-binary suitesparse-graphblas suitesparse-graphblas${psgver}
+              python -m pip install --no-deps --no-binary suitesparse-graphblas suitesparse-graphblas${psgver}
 
               # Add the below line to the conda install command above if installing from test.pypi.org
               # ${{ steps.sourcetype.outputs.selected == 'source' && 'setuptools setuptools-git-versioning wheel cython' || '' }} \
-              # pip install --no-deps --no-build-isolation --no-binary suitesparse-graphblas --index-url https://test.pypi.org/simple/ suitesparse-graphblas==7.4.3.3
+              # python -m pip install --no-deps --no-build-isolation --no-binary suitesparse-graphblas --index-url https://test.pypi.org/simple/ suitesparse-graphblas==7.4.3.3
           elif [[ ${{ steps.sourcetype.outputs.selected }} == "upstream" ]]; then
-              pip install --no-deps git+https://github.com/GraphBLAS/python-suitesparse-graphblas.git@main#egg=suitesparse-graphblas
+              python -m pip install --no-deps git+https://github.com/GraphBLAS/python-suitesparse-graphblas.git@main#egg=suitesparse-graphblas
           fi
-          pip install --no-deps -e .
+          python -m pip install --no-deps -e .
       - name: python-suitesparse-graphblas tests
         run: |
           # Don't use our conftest.py ; allow `test_print_jit_config` to fail if it doesn't exist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -160,6 +160,11 @@ repos:
   #    rev: v1.14.2
   #    hooks:
   #      - id: zizmor
+  - repo: https://github.com/pysentry/pysentry-pre-commit
+    rev: v0.4.6
+    hooks:
+      - id: pysentry
+        args: ["--format=human", "--fail-on=low", "--sources=pypa,osv,pypi"]
   - repo: meta
     hooks:
       - id: check-hooks-apply
@@ -180,6 +185,25 @@ repos:
         name: Disallow _ in permalinks
         language: pygrep
         entry: "^permalink:.*_.*"
+      - id: disallow-ai-dashes
+        # AI-ism: em-dash, en-dash, " -- " separator, or "word--jam".
+        # See ``scripts/find_aiisms.sh`` for the manual / branch-diff variant
+        # and ``ai/CLAUDE.md`` "Writing Style" for the rationale.
+        name: Disallow em/en-dash and ' -- ' as a separator
+        language: pygrep
+        entry: "—|–| -- |[A-Za-z0-9]--"
+        types_or: [python, rst, markdown, toml, yaml, shell]
+        # README intentionally uses en-dash. docs/conf.py + jit_diagnostics.py
+        # use ``# --- Section ---`` banner comments / print output, which the
+        # regex also matches. find_aiisms.sh contains the matching regex.
+        exclude: |
+          (?x)^(
+            README\.md
+            | docs/conf\.py
+            | scripts/jit_diagnostics\.py
+            | scripts/find_aiisms\.sh
+            | \.pre-commit-config\.yaml
+          )$
       # Add `--hook-stage manual` to pre-commit command to run (very slow)
       # It's probably better (and faster!) to simply run `pylint graphblas/some/file.py`
       - id: pylint

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -29,5 +29,6 @@ mypy
 # For building docs
 nbsphinx
 numpydoc
-pydata-sphinx-theme
-sphinx-panels
+pydata-sphinx-theme>=0.15
+sphinx>=7
+sphinx-design

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -5,8 +5,12 @@
   margin-bottom: 30px;
 }
 
-.intro-card:hover {
-  box-shadow: 0.2rem 0.5rem 1rem var(--pst-color-link) !important;
+html[data-theme="light"] .intro-card:hover {
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.18) !important;
+}
+
+html[data-theme="dark"] .intro-card:hover {
+  box-shadow: 0 0.5rem 1rem var(--pst-color-link) !important;
 }
 
 .intro-card .card-header {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,7 @@ del version
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "numpydoc", "sphinx_panels", "nbsphinx"]
+extensions = ["sphinx.ext.autodoc", "numpydoc", "sphinx_design", "nbsphinx"]
 html_css_files = ["custom.css", "matrix.css"]
 html_js_files = ["custom.js"]
 

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.11
+  - python=3.13
   - pip
   # python-graphblas dependencies
   - donfig
@@ -16,8 +16,8 @@ dependencies:
   - pandas
   - scipy>=1.7.0
   # docs dependencies
-  - commonmark # For RTD
   - nbsphinx
   - numpydoc
-  - pydata-sphinx-theme=0.13.1
-  - sphinx-panels=0.6.0
+  - pydata-sphinx-theme>=0.15
+  - sphinx>=7
+  - sphinx-design

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -30,10 +30,10 @@ Optional Dependencies
 The following are not required by ``python-graphblas``, but may be needed for certain functionality
 to work.
 
-  - `pandas <https://pandas.pydata.org/>`__ -- required for nicer ``__repr__``
-  - `matplotlib <https://matplotlib.org>`__ -- required for basic plotting of graphs
-  - `scipy <https://scipy.org/>`__ -- used in ``io`` module to read/write ``scipy.sparse`` format
-  - `networkx <https://networkx.org>`__ -- used in ``io`` module to interface with networkx graphs
+  - `pandas <https://pandas.pydata.org/>`__: required for nicer ``__repr__``
+  - `matplotlib <https://matplotlib.org>`__: required for basic plotting of graphs
+  - `scipy <https://scipy.org/>`__: used in ``io`` module to read/write ``scipy.sparse`` format
+  - `networkx <https://networkx.org>`__: used in ``io`` module to interface with networkx graphs
 
 GraphBLAS Fundamentals
 ----------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,60 +19,51 @@ Licensed under the `Apache 2.0 license <https://www.apache.org/licenses/LICENSE-
    api_reference/index
    contributor_guide/index
 
-.. panels::
-    :card: + intro-card text-center
-    :column: col-lg-6 col-md-6 col-sm-6 col-xs-12 d-flex
+.. grid:: 1 2 2 2
+    :gutter: 3
 
-    ---
-    :fa:`play-circle,fa-3x`
+    .. grid-item-card:: Getting Started
+        :link: getting_started/index
+        :link-type: doc
+        :text-align: center
+        :class-card: intro-card
 
-    Getting Started
-    ^^^^^^^^^^^^^^^
+        :octicon:`rocket;3em;sd-text-primary`
 
-    .. link-button:: getting_started
-        :text:
-        :classes: stretched-link
+        Exactly what you need to get up and running with
+        python-graphblas. Contains a short introduction
+        to the main ideas behind GraphBLAS.
 
-    Exactly what you need to get up and running with
-    python-graphblas. Contains a short introduction
-    to the main ideas behind GraphBLAS.
+    .. grid-item-card:: User Guide
+        :link: user_guide/index
+        :link-type: doc
+        :text-align: center
+        :class-card: intro-card
 
-    ---
-    :fa:`code,fa-3x`
+        :octicon:`book;3em;sd-text-primary`
 
-    User Guide
-    ^^^^^^^^^^
+        The user guide covers the fundamental ideas and usage
+        patterns of python-graphblas. It also contains an example
+        notebook showing Single-Source Shortest Path.
 
-    .. link-button:: user_guide
-        :text:
-        :classes: stretched-link
+    .. grid-item-card:: API Reference
+        :link: api_reference/index
+        :link-type: doc
+        :text-align: center
+        :class-card: intro-card
 
-    The user guide covers the fundamental ideas and usage
-    patterns of python-graphblas. It also contains an example
-    notebook showing Single-Source Shortest Path.
+        :octicon:`code;3em;sd-text-primary`
 
-    ---
-    :fa:`cogs,fa-3x`
+        The API reference contains details about each class and method.
+        It assumes familiarity with the core ideas and usage patterns.
 
-    API Reference
-    ^^^^^^^^^^^^^
+    .. grid-item-card:: Contributor Guide
+        :link: contributor_guide/index
+        :link-type: doc
+        :text-align: center
+        :class-card: intro-card
 
-    .. link-button:: api_reference
-        :text:
-        :classes: stretched-link
+        :octicon:`people;3em;sd-text-primary`
 
-    The API reference contains details about each class and method.
-    It assumes familiarity with the core ideas and usage patterns.
-
-    ---
-    :fa:`plus-circle,fa-3x`
-
-    Contributor Guide
-    ^^^^^^^^^^^^^^^^^
-
-    .. link-button:: contributor_guide
-        :text:
-        :classes: stretched-link
-
-    Find out how you can contribute and make python-graphblas
-    better for everyone.
+        Find out how you can contribute and make python-graphblas
+        better for everyone.

--- a/docs/user_guide/fundamentals.rst
+++ b/docs/user_guide/fundamentals.rst
@@ -183,8 +183,8 @@ Comparing Objects
 Comparing objects can be tricky because of the need to check the shape, sparsity pattern, and values
 of both objects. Two convenience methods exist to simplify comparisons.
 
-1. isequal -- for checking exact matches
-2. isclose -- for checking approximately equal for floating point dtypes
+1. isequal: for checking exact matches
+2. isclose: for checking approximately equal for floating point dtypes
 
 By default, the types do not need to match as long as the values are equivalent. If exact dtype matching
 is required, set the ``check_dtype`` keyword argument to True.

--- a/docs/user_guide/io.rst
+++ b/docs/user_guide/io.rst
@@ -138,7 +138,7 @@ Matrix Market files
 
 The `Matrix Market file format <https://math.nist.gov/MatrixMarket/formats.html>`_ is a common
 file format for storing sparse arrays in human-readable ASCII.
-Matrix Market files--also called MM files--often use ".mtx" file extension.
+Matrix Market files (also called MM files) often use ".mtx" file extension.
 For example, many datasets in MM format can be found in `the SuiteSparse Matrix Collection <https://sparse.tamu.edu/>`_.
 
 Use ``gb.io.mmread()`` to read a Matrix Market file to a python-graphblas Matrix,

--- a/docs/user_guide/operations.rst
+++ b/docs/user_guide/operations.rst
@@ -8,9 +8,9 @@ Matrix Multiply
 The GraphBLAS spec contains three methods for matrix multiplication, depending on whether
 the inputs are Matrix or Vector.
 
-  - **mxm** -- Matrix-Matrix multiplication
-  - **mxv** -- Matrix-Vector multiplication
-  - **vxm** -- Vector-Matrix multiplication
+  - **mxm**: Matrix-Matrix multiplication
+  - **mxv**: Matrix-Vector multiplication
+  - **vxm**: Vector-Matrix multiplication
 
 These three methods exist on python-graphblas collections, but the preferred approach is using
 the ``@`` symbol, which indicates matrix multiplication in Python.

--- a/docs/user_guide/operators.rst
+++ b/docs/user_guide/operators.rst
@@ -19,21 +19,21 @@ Example usage:
 
 Common unary operators are:
 
-  - **identity** -- returns the input unchanged
-  - **abs** -- absolute value
-  - **ainv** -- additive inverse (f(x) = -x)
-  - **minv** -- multiplicative inverse (f(x) = 1/x)
-  - **lnot** -- logical not (True -> False)
-  - **bnot** -- binary not (110010 -> 001101)
-  - **one** -- result is always 1.0 (or equivalent for the dtype)
-  - **round** -- floating-point round function
-  - **floor** -- floating-point floor function
-  - **ceil** -- floating-point ceiling function
-  - **sin** -- trigonometric sine function
-  - **cos** -- trigonometric cosine function
-  - **tan** -- trigonometric tangent function
-  - **exp** -- exponential
-  - **log** -- logarithm
+  - **identity**: returns the input unchanged
+  - **abs**: absolute value
+  - **ainv**: additive inverse (f(x) = -x)
+  - **minv**: multiplicative inverse (f(x) = 1/x)
+  - **lnot**: logical not (True -> False)
+  - **bnot**: binary not (110010 -> 001101)
+  - **one**: result is always 1.0 (or equivalent for the dtype)
+  - **round**: floating-point round function
+  - **floor**: floating-point floor function
+  - **ceil**: floating-point ceiling function
+  - **sin**: trigonometric sine function
+  - **cos**: trigonometric cosine function
+  - **tan**: trigonometric tangent function
+  - **exp**: exponential
+  - **log**: logarithm
 
 Unary operators are located in the ``graphblas.unary`` namespace. Additional unary operators
 registered from numpy are located in ``graphblas.unary.numpy``.
@@ -56,32 +56,32 @@ Example usage:
 
 Common binary operators are:
 
-  - **pair** -- result is always 1.0 (or equivalent for the dtype)
-  - **first** -- f(a, b) = a
-  - **second** -- f(a, b) = b
-  - **min** -- min(a, b)
-  - **max** -- max(a, b)
-  - **eq** -- a == b
-  - **ne** -- a != b
-  - **gt** -- a > b
-  - **lt** -- a < b
-  - **ge** -- a >= b
-  - **le** -- a <= b
-  - **plus** -- a + b
-  - **minus** -- a - b
-  - **times** -- a * b
-  - **truediv** -- a / b
-  - **fmod** -- a % b
-  - **pow** -- a ** b
-  - **atan2** -- math.atan2(a, b)
-  - **lor** -- logical or (a | b)
-  - **land** -- logical and (a & b)
-  - **lxor** -- logical xor (a ^ b)
-  - **lxnor** -- logical xnor ~(a ^ b)
-  - **bor** -- binary or
-  - **band** -- binary and
-  - **bxor** -- binary xor
-  - **bxnor** -- binary xnor
+  - **pair**: result is always 1.0 (or equivalent for the dtype)
+  - **first**: f(a, b) = a
+  - **second**: f(a, b) = b
+  - **min**: min(a, b)
+  - **max**: max(a, b)
+  - **eq**: a == b
+  - **ne**: a != b
+  - **gt**: a > b
+  - **lt**: a < b
+  - **ge**: a >= b
+  - **le**: a <= b
+  - **plus**: a + b
+  - **minus**: a - b
+  - **times**: a * b
+  - **truediv**: a / b
+  - **fmod**: a % b
+  - **pow**: a ** b
+  - **atan2**: math.atan2(a, b)
+  - **lor**: logical or (a | b)
+  - **land**: logical and (a & b)
+  - **lxor**: logical xor (a ^ b)
+  - **lxnor**: logical xnor ~(a ^ b)
+  - **bor**: binary or
+  - **band**: binary and
+  - **bxor**: binary xor
+  - **bxnor**: binary xnor
 
 Binary operators are located in the ``graphblas.binary`` namespace. Additional binary operators
 registered from numpy are located in ``graphblas.binary.numpy``.
@@ -107,15 +107,15 @@ Example usage:
 
 Common monoids are:
 
-  - **any** -- return either input
-  - **min** -- min(a, b)
-  - **max** -- max(a, b)
-  - **plus** -- a + b
-  - **times** -- a * b
-  - **land** -- a & b
-  - **lor** -- a | b
-  - **lxor** -- a ^ b
-  - **lxnor** -- ~(a ^ b)
+  - **any**: return either input
+  - **min**: min(a, b)
+  - **max**: max(a, b)
+  - **plus**: a + b
+  - **times**: a * b
+  - **land**: a & b
+  - **lor**: a | b
+  - **lxor**: a ^ b
+  - **lxnor**: ~(a ^ b)
 
 Monoids are located in the ``graphblas.monoid`` namespace. Additional monoids registered from
 numpy are located in ``graphblas.monoid.numpy``.
@@ -187,26 +187,26 @@ Example usage with a thunk parameter:
 
 Defined IndexUnary operators are:
 
-  - **index** -- return the vector index
-  - **rowindex** -- return the matrix row index
-  - **colindex** -- return the matrix column index
-  - **diagindex** -- return the matrix diagonal index (i.e. column - row)
-  - **tril** -- lower triangle matrix (True if column >= row)
-  - **triu** -- upper triangle matrix (True if column <= row)
-  - **diag** -- matrix diagonal (True if row == column)
-  - **offdiag** -- matrix off-diagonal (True if row != column)
-  - **indexle** -- vector index <= thunk
-  - **indexgt** -- vector index > thunk
-  - **rowle** -- matrix row index <= thunk
-  - **rowgt** -- matrix row index > thunk
-  - **colle** -- matrix column index <= thunk
-  - **colgt** -- matrix column index > thunk
-  - **valueeq** -- value == thunk
-  - **valuene** -- value != thunk
-  - **valuelt** -- value < thunk
-  - **valuele** -- value <= thunk
-  - **valuegt** -- value > thunk
-  - **valuege** -- value >= thunk
+  - **index**: return the vector index
+  - **rowindex**: return the matrix row index
+  - **colindex**: return the matrix column index
+  - **diagindex**: return the matrix diagonal index (i.e. column - row)
+  - **tril**: lower triangle matrix (True if column >= row)
+  - **triu**: upper triangle matrix (True if column <= row)
+  - **diag**: matrix diagonal (True if row == column)
+  - **offdiag**: matrix off-diagonal (True if row != column)
+  - **indexle**: vector index <= thunk
+  - **indexgt**: vector index > thunk
+  - **rowle**: matrix row index <= thunk
+  - **rowgt**: matrix row index > thunk
+  - **colle**: matrix column index <= thunk
+  - **colgt**: matrix column index > thunk
+  - **valueeq**: value == thunk
+  - **valuene**: value != thunk
+  - **valuelt**: value < thunk
+  - **valuele**: value <= thunk
+  - **valuegt**: value > thunk
+  - **valuege**: value >= thunk
 
 IndexUnary operators are located in two places.
 

--- a/docs/user_guide/udf.rst
+++ b/docs/user_guide/udf.rst
@@ -87,7 +87,7 @@ User-defined types (UDTs)
 -------------------------
 
 Pass ``is_udt=True`` when your UDF operates on user-defined record or array
-types. See :doc:`udt` for the full story. In short:
+types. See :doc:`udt` for the full story.
 
 .. code-block:: python
 
@@ -120,12 +120,12 @@ works in ``ewise_mult``, ``ewise_add``, and the other elementwise paths:
 
     from graphblas import indexbinary, Matrix
 
-    def discounted_distance(x, ix, jx, y, iy, jy, theta):
+    def discounted_sum(x, ix, jx, y, iy, jy, theta):
         return (x + y) * theta
 
-    indexbinary.register_new("discounted_dist", discounted_distance)
+    indexbinary.register_new("discounted_sum", discounted_sum)
 
-    bound = indexbinary.discounted_dist[float](0.5)   # theta = 0.5
+    bound = indexbinary.discounted_sum[float](0.5)   # theta = 0.5
     A = Matrix.from_coo([0, 1], [0, 1], [1.0, 2.0])
     B = Matrix.from_coo([0, 1], [0, 1], [3.0, 4.0])
     C = A.ewise_mult(B, bound).new()

--- a/docs/user_guide/udt.rst
+++ b/docs/user_guide/udt.rst
@@ -106,13 +106,16 @@ Built-in operators on UDTs
 The following operators auto-lift to any UDT on first use:
 
 - BinaryOps: ``plus``, ``minus``, ``times``, ``truediv``, ``floordiv``,
-  ``min``, ``max``, ``eq``, ``ne``.
+  ``min``, ``max``, ``eq``, ``ne``. The positional selectors ``first``,
+  ``second``, ``any``, and ``pair`` work too, since they don't touch field
+  values.
 - UnaryOps: ``ainv``, ``abs``.
 - Monoids: ``plus``, ``times``, ``min``, ``max``, ``any``.
 - Semirings combining a UDT-lifting monoid with a UDT-lifting BinaryOp
   (e.g., ``plus_times``, ``min_plus``, ``max_times``, ``any_first``).
 - Aggregators built on those monoids: ``sum``, ``prod``, ``min``, ``max``,
-  ``any_value``, ``count``, ``first``, ``last``.
+  ``any_value``, ``count``. The positional ``agg.ss.first`` and
+  ``agg.ss.last`` work on any dtype, including UDTs.
 
 For example:
 
@@ -126,8 +129,11 @@ For example:
     total       = v.reduce(agg.sum[edge_dtype]).new()  # field-wise reduce
 
 The lift is field-by-field for record UDTs and element-by-element for array
-UDTs. Field types that don't support the operation raise ``UdfParseError``
-on the first lookup (e.g., ``binary.floordiv[complex_udt]``).
+UDTs. Field types that don't support the operation raise ``KeyError`` on the
+first lookup. ``binary.min``, ``binary.max``, and ``binary.floordiv`` reject
+UDTs with any complex leaf (no ordering, no integer modulus); use ``plus``,
+``minus``, ``times``, or ``truediv`` for complex arithmetic, or register a
+custom binary op.
 
 Composite aggregators (``agg.hypot``, ``agg.L1norm``, ``agg.Linfnorm``,
 ``agg.sum_of_squares``, ``agg.sum_of_inverses``) do *not* auto-lift to UDTs;
@@ -204,20 +210,29 @@ Inspect what SuiteSparse is JIT-ing from Python:
 
 JIT is skipped when:
 
-- The UDT name (or any field name) is a C reserved word (``class``,
-  ``return``, ...) or a stdlib macro/typedef pulled in by ``GraphBLAS.h``
-  (``NULL``, ``FILE``, ``M_PI``, ``complex``, ...). The op falls through
-  to the Numba cfunc path.
+- A field name (or the UDT name, if you supplied one) is a C reserved word
+  (``class``, ``return``, ...) or a stdlib macro/typedef pulled in by
+  ``GraphBLAS.h`` (``NULL``, ``FILE``, ``M_PI``, ``complex``, ...). The op
+  falls through to the Numba cfunc path.
 - A field type isn't in the numpy-to-C map (rare; the standard numeric
   scalar types all map).
-- The UDT has no usable name. Anonymous registration without an explicit
-  ``name=`` argument produces a default like ``"{'x': INT64}"``, which is
-  not a valid C identifier.
+- The numpy layout doesn't match what a C compiler would produce. The most
+  common case is a packed record with mixed-width fields (e.g.,
+  ``np.dtype([("a", int32), ("b", float64)])`` without ``align=True``).
+  Pass ``align=True`` to ``np.dtype``, or use the dict / dataclass form,
+  which auto-aligns.
 - The JIT compiler isn't usable after auto-fix (see below).
 
-The first time auto-lift produces a non-JIT'd op in a process, a one-time
-``graphblas.exceptions.NoJITWarning`` (a subclass of ``UserWarning``) is
-emitted with the cause and the remediation. Silence it by category or by
+Anonymous UDTs (no ``name=`` argument) still take the JIT path: a synthetic
+``_gbudt_NNN`` C name is minted so SuiteSparse always has a registerable
+identifier. Pass ``name=`` only for readable JIT cache filenames and
+introspection.
+
+The first time auto-lift produces a non-JIT'd op for a given ``(op, dtype)``
+pair in a process, a ``graphblas.exceptions.NoJITWarning`` (a subclass of
+``UserWarning``) is emitted with the cause and the remediation. The warning
+fires once per ``(op, dtype)`` rather than once per process, so distinct
+fallback causes each surface a warning. Silence it by category or by
 message::
 
     import warnings
@@ -236,13 +251,14 @@ A conda-installed ``python-suitesparse-graphblas`` bakes in the build host's
 compiler path (e.g., ``/Users/runner/...``), which doesn't exist on user
 machines. With the bogus default, SuiteSparse emits the JIT ``.c`` source
 but never compiles a ``.dylib`` or ``.so``, and silently falls back to the
-cfunc path. **The 2-3x JIT speedup is invisibly lost.**
+cfunc path. The 2-3x JIT speedup is silently lost.
 
 python-graphblas auto-fixes this at import. If ``jit_c_compiler_name``
 doesn't exist on disk, it is replaced with one from ``$CONDA_PREFIX/bin/``
 (or from ``sysconfig`` for pure-pip installs), and ``jit_c_control`` is
-bumped from the SS default ``'run'`` (load only) to ``'on'`` (compile and
-load). When the default config is already valid, only the mode bump applies.
+bumped from the SS default ``'run'`` (run cached kernels only; no compile,
+no load from disk) to ``'on'`` (compile, load, and run). When the default
+config is already valid, only the mode bump applies.
 
 Call the helper manually to re-fix or verify::
 

--- a/environment.yml
+++ b/environment.yml
@@ -45,8 +45,9 @@ dependencies:
   # For building docs
   - nbsphinx
   - numpydoc
-  - pydata-sphinx-theme
-  - sphinx-panels
+  - pydata-sphinx-theme>=0.15
+  - sphinx>=7
+  - sphinx-design
   # For building logo
   - drawsvg
   - cairosvg
@@ -55,7 +56,6 @@ dependencies:
   # - black
   # - black-jupyter
   # - codespell
-  # - commonmark
   # - cython
   # - cytoolz
   # - distributed

--- a/graphblas/core/dtypes.py
+++ b/graphblas/core/dtypes.py
@@ -296,10 +296,7 @@ def register_anonymous(dtype, name=None):
         # We don't yet have C definitions
         np_repr = _dtype_to_string(dtype).encode()
         if len(np_repr) > lib.GxB_MAX_NAME_LEN:
-            msg = (
-                f"UDT repr is too large to serialize ({len(repr(dtype).encode())} > "
-                f"{lib.GxB_MAX_NAME_LEN})."
-            )
+            msg = f"UDT repr is too large to serialize ({len(np_repr)} > {lib.GxB_MAX_NAME_LEN})."
             if name is not None:
                 np_repr = name.encode()[: lib.GxB_MAX_NAME_LEN]
             else:
@@ -607,13 +604,53 @@ def _dtype_to_string(dtype):
         np_type = dtype.np_type
     s = str(np_type)
     try:
-        if np.dtype(literal_eval(s)) == np_type:  # pragma: no branch (safety)
+        if np.dtype(literal_eval(s)) == np_type:
             return s
     except Exception:
         pass
-    if np.dtype(np_type.str) != np_type:  # pragma: no cover (safety)
-        raise ValueError(f"Unable to reliably convert dtype to string and back: {dtype}")
-    return repr(np_type.str)
+    if np.dtype(np_type.str) == np_type:
+        return repr(np_type.str)
+    # Some nested dtypes (e.g. ``align=True`` outer + ``packed`` inner) don't
+    # round-trip via ``str(np_type)`` because numpy's reconstruction enforces
+    # the outer's alignment on the inner. Fall back to an explicit per-field
+    # dict using literal offsets/itemsize, which encodes the exact layout
+    # without invoking ``align``. ``literal_eval`` accepts the result, so
+    # ``_string_to_dtype`` doesn't need a special case for it.
+    return repr(_dtype_to_explicit_dict(np_type))
+
+
+def _dtype_to_explicit_dict(np_type):
+    """Encode ``np_type`` as a plain dict/tuple/str tree of literals.
+
+    Layout-preserving fallback for :func:`_dtype_to_string`. Records become a
+    ``{names, formats, offsets, itemsize}`` dict whose nested ``formats`` may
+    be further nested dicts; array dtypes become a ``(base_str, shape)``
+    tuple. The result round-trips through ``np.dtype(literal_eval(s))``
+    without ever using ``aligned=True``, so the original byte layout is
+    preserved verbatim even for the aligned-outer / packed-inner cases.
+    """
+    if np_type.names is not None:
+        formats = []
+        for name in np_type.names:
+            sub = np_type.fields[name][0]
+            if sub.names is not None or sub.subdtype is not None:
+                formats.append(_dtype_to_explicit_dict(sub))
+            else:
+                formats.append(sub.str)
+        return {
+            "names": list(np_type.names),
+            "formats": formats,
+            "offsets": [np_type.fields[name][1] for name in np_type.names],
+            "itemsize": np_type.itemsize,
+        }
+    if np_type.subdtype is not None:
+        base, shape = np_type.subdtype
+        if base.names is not None:
+            base_repr = _dtype_to_explicit_dict(base)
+        else:
+            base_repr = base.str
+        return (base_repr, shape)
+    return np_type.str
 
 
 def _string_to_dtype(s):

--- a/graphblas/core/infixmethods.py
+++ b/graphblas/core/infixmethods.py
@@ -65,7 +65,7 @@ def __xor__(self, other):
     if expr.dtype != BOOL:
         raise TypeError(
             f"The __xor__ infix operator, `x ^ y`, is not supported for {expr.dtype.name} dtype."
-            "  It is only supported for BOOL dtype (and it uses ewise_add--the union)."
+            "  It is only supported for BOOL dtype (and it uses ewise_add, the union)."
         )
     return expr
 
@@ -75,7 +75,7 @@ def __rxor__(self, other):
     if expr.dtype != BOOL:
         raise TypeError(
             f"The __xor__ infix operator, `x ^ y`, is not supported for {expr.dtype.name} dtype."
-            "  It is only supported for BOOL dtype (and it uses ewise_add--the union)."
+            "  It is only supported for BOOL dtype (and it uses ewise_add, the union)."
         )
     return expr
 
@@ -92,7 +92,7 @@ def __ixor__(self, other):
     elif other.dtype != BOOL:
         raise TypeError(
             f"The __ixor__ infix operator, `x ^= y`, is not supported for {other.dtype.name} "
-            "dtype.  It is only supported for BOOL dtype (and it uses ewise_add--the union)."
+            "dtype.  It is only supported for BOOL dtype (and it uses ewise_add, the union)."
         )
     else:
         self(binary.lxor) << other
@@ -111,13 +111,13 @@ def __ior__(self, other):
         if expr.dtype != BOOL:
             raise TypeError(
                 f"The __ior__ infix operator, `x |= y`, is not supported for {expr.dtype.name} "
-                "dtype.  It is only supported for BOOL dtype (and it uses ewise_add--the union)."
+                "dtype.  It is only supported for BOOL dtype (and it uses ewise_add, the union)."
             )
         self << expr
     elif other.dtype != BOOL:
         raise TypeError(
             f"The __ior__ infix operator, `x |= y`, is not supported for {other.dtype.name} "
-            "dtype.  It is only supported for BOOL dtype (and it uses ewise_add--the union)."
+            "dtype.  It is only supported for BOOL dtype (and it uses ewise_add, the union)."
         )
     else:
         self(binary.lor) << other
@@ -129,7 +129,7 @@ def __iand__(self, other):
     if expr.dtype != BOOL:
         raise TypeError(
             f"The __iand__ infix operator, `x &= y`, is not supported for {expr.dtype.name} dtype."
-            "  It is only supported for BOOL dtype (and it uses ewise_mult--the intersection)."
+            "  It is only supported for BOOL dtype (and it uses ewise_mult, the intersection)."
         )
     self << expr
     return self

--- a/graphblas/core/operator/agg.py
+++ b/graphblas/core/operator/agg.py
@@ -122,16 +122,10 @@ class Aggregator:
         return self._typed_ops[dtype]
 
     def __contains__(self, dtype):
-        # Behavior change vs. earlier releases: ``dtype in agg.sum`` for a UDT
-        # used to be an O(1) ``dtype in self.types`` lookup that would return
-        # ``False`` even when the underlying monoid could be auto-lifted for
-        # that UDT. Now it goes through ``__getitem__``, which compiles the
-        # field-wise monoid on first use and caches both the resolved return
-        # type in ``self.types`` and the ``TypedAggregator`` in
-        # ``self._typed_ops``. The first ``in`` against a fresh UDT triggers
-        # a Numba compile; subsequent ones are cheap. ``__getitem__``'s UDT
-        # lift narrows the catch to ``KeyError``/``TypeError``/``UdfParseError``;
-        # the same set is caught here.
+        # Routes through ``__getitem__`` (which can lift the underlying
+        # monoid for a UDT) so ``dtype in agg.sum`` reports True for any
+        # UDT the monoid can auto-compile. Catches the same exception set
+        # ``__getitem__`` raises.
         try:
             self[dtype]
         except (KeyError, TypeError, UdfParseError):
@@ -144,6 +138,8 @@ class Aggregator:
         return f"agg.{self.name}"
 
     def __reduce__(self):
+        # Aggregator has no register_anonymous/register_new, so every
+        # instance is a module-level singleton; pickle by name.
         if self.name in agg._deprecated:
             return f"agg.ss.{self.name}"
         return f"agg.{self.name}"

--- a/graphblas/core/operator/base.py
+++ b/graphblas/core/operator/base.py
@@ -5,8 +5,8 @@ from types import BuiltinFunctionType, ModuleType
 
 from ... import _STANDARD_OPERATOR_NAMES, backend, op
 from ...dtypes import BOOL, INT8, UINT64, _supports_complex, lookup_dtype
-from ...exceptions import UdfParseError
-from .. import _has_numba, _supports_udfs, lib
+from ...exceptions import UdfParseError, check_status_carg
+from .. import _has_numba, _supports_udfs, ffi, lib
 from ..expr import InfixExprBase
 from ..utils import output_type
 
@@ -95,6 +95,20 @@ def _hasop(module, name):
     )
 
 
+def _bool_to_int8(dtype):
+    """Return INT8 if ``dtype`` is BOOL, else the dtype unchanged.
+
+    Numba can't compile cfuncs that read or write ``CPointer(boolean)``
+    (errors like ``cannot store i1 to i8*`` / ``cond is not i1: i8``); see
+    numba/numba#5395. Routing BOOL through INT8 sidesteps that; GraphBLAS
+    coerces back at the cfunc boundary.
+
+    MAINT 2026-05-24: still hits on Numba 0.65. Re-test periodically and
+    drop the INT8 routing when upstream is fixed.
+    """
+    return INT8 if dtype == BOOL else dtype
+
+
 class OpPath:
     def __init__(self, parent, name):
         self._parent = parent
@@ -166,6 +180,41 @@ def _call_op(op, left, right=None, thunk=None, **kwargs):
 
 
 if _has_numba:
+
+    def _finalize_udt_op(parent_op, dtype, dtype2, ret_type, wrapper, wrapper_sig, typed_user_cls):
+        """Compile the cfunc, allocate the ``GrB`` op, wrap it, and cache it.
+
+        Shared tail for ``_compile_udt`` in UnaryOp / BinaryOp / IndexUnaryOp /
+        SelectOp. Looks up the SuiteSparse handle type and ``_new`` symbol
+        from ``typed_user_cls.opclass``. ``dtype2`` is ``None`` for unary
+        ops; the rest pass both. Returns the cached ``TypedUser*Op``.
+        """
+        wrapper = numba.cfunc(wrapper_sig, nopython=True)(wrapper)
+        c_typename = _GB_OBJ_C_TYPENAME[typed_user_cls.opclass]
+        error_label = c_typename.removeprefix("GrB_").removeprefix("GxB_")
+        gb_obj = ffi.new(f"{c_typename}*")
+        new_func = getattr(lib, f"{c_typename}_new")
+        if dtype2 is None:
+            check_status_carg(
+                new_func(gb_obj, wrapper.cffi, ret_type._carg, dtype._carg),
+                error_label,
+                gb_obj[0],
+            )
+            op = typed_user_cls(parent_op, parent_op.name, dtype, ret_type, gb_obj[0])
+            key = dtype
+        else:
+            check_status_carg(
+                new_func(gb_obj, wrapper.cffi, ret_type._carg, dtype._carg, dtype2._carg),
+                error_label,
+                gb_obj[0],
+            )
+            op = typed_user_cls(
+                parent_op, parent_op.name, dtype, ret_type, gb_obj[0], dtype2=dtype2
+            )
+            key = (dtype, dtype2)
+        parent_op._udt_types[key] = ret_type
+        parent_op._udt_ops[key] = op
+        return op
 
     def _compile_udf_for_udt(numba_func, sig, *, op_kind, op_name, dtypes):
         """Compile ``sig`` and re-raise Numba compilation errors as ``UdfParseError``.
@@ -307,7 +356,7 @@ if _has_numba:
         if dtype == BOOL:
             # Numba can't compile bool ptrs (numba/numba#5395); expose them
             # as int8 and cast on deref.
-            # MAINT 2026-05-17: re-verified on Numba 0.65; re-test periodically.
+            # MAINT 2026-05-24: still hits on Numba 0.65; re-test periodically.
             return "", f"bool({var}_ptr[0])", nt.CPointer(INT8.numba_type)
         return "", f"{var}_ptr[0]", nt.CPointer(dtype.numba_type)
 
@@ -458,6 +507,23 @@ if _has_numba:
         return wrapper, wrapper_sig
 
 
+# Maps ``opclass`` to the SuiteSparse C type name SS allocates for it.
+# ``IndexBinaryOp`` is in the GxB_ namespace (SS-specific, added in 9.4);
+# the rest are GrB_. ``SelectOp`` is implemented on top of
+# ``GrB_IndexUnaryOp`` (BOOL-returning), so its handle frees through the
+# same ``GrB_IndexUnaryOp_free``. Used by ``TypedOpBase.__del__`` to
+# synthesize the pointer cell for ``<C type>_free``.
+_GB_OBJ_C_TYPENAME = {
+    "UnaryOp": "GrB_UnaryOp",
+    "BinaryOp": "GrB_BinaryOp",
+    "IndexUnaryOp": "GrB_IndexUnaryOp",
+    "SelectOp": "GrB_IndexUnaryOp",
+    "IndexBinaryOp": "GxB_IndexBinaryOp",
+    "Monoid": "GrB_Monoid",
+    "Semiring": "GrB_Semiring",
+}
+
+
 class TypedOpBase:
     __slots__ = (
         "parent",
@@ -468,8 +534,17 @@ class TypedOpBase:
         "gb_name",
         "_type2",
         "_jit_c_info",
+        "_owns_gb_obj_inst",
         "__weakref__",
     )
+    # Subclasses whose ``gb_obj`` was allocated via ``GrB_<Type>_new`` /
+    # ``GxB_<Type>_new`` (TypedUser*Op, _BoundIndexBinaryOp) override this so
+    # ``__del__`` frees the SuiteSparse handle. Built-in typed ops point at
+    # SuiteSparse's permanent built-in singletons and must never free.
+    # Specific instances can override via ``_owns_gb_obj_inst`` (set by
+    # the constructor); ``SelectOp._from_indexunary`` aliases an existing
+    # ``GrB_IndexUnaryOp`` and must clear ownership to avoid a double free.
+    _owns_gb_obj = False
 
     def __init__(self, parent, name, type_, return_type, gb_obj, gb_name, dtype2=None):
         self.parent = parent
@@ -483,6 +558,10 @@ class TypedOpBase:
         # for this typed op; ``None`` for built-in ops and for UDT ops with
         # no JIT path.
         self._jit_c_info = None
+        # Per-instance ownership override; defaults to the class attribute.
+        # ``SelectOp._from_indexunary`` flips this to ``False`` on aliasing
+        # TypedUserSelectOps so only the IndexUnaryOp frees the handle.
+        self._owns_gb_obj_inst = type(self)._owns_gb_obj
 
     @property
     def jit_c_name(self):
@@ -513,6 +592,32 @@ class TypedOpBase:
             return (getitem, (self.parent, self.type))
         return (getitem, (self.parent, (self.type, self._type2)))
 
+    def __del__(self):
+        # Free the SuiteSparse handle we allocated. Built-in typed ops alias
+        # SuiteSparse's permanent built-in singletons and must never free, so
+        # gate on the per-instance owns flag (defaults to the class
+        # attribute; the alias case overrides to False). Mirrors the
+        # ``Matrix.__del__`` / ``Vector.__del__`` pattern.
+        if not getattr(self, "_owns_gb_obj_inst", False):
+            return
+        gb_obj = getattr(self, "gb_obj", None)
+        if gb_obj is None or lib is None or ffi is None:
+            # Interpreter shutdown can clear ``lib`` / ``ffi`` before
+            # finalizers run; SS will clean up the handles at process exit.
+            return
+        c_type_name = _GB_OBJ_C_TYPENAME.get(self.opclass)
+        if c_type_name is None:  # pragma: no cover (defensive)
+            return
+        free_fn = getattr(lib, f"{c_type_name}_free", None)
+        if free_fn is None:
+            # ``GxB_IndexBinaryOp_free`` is absent on SS < 9.4; that build
+            # also can't allocate one in the first place, so this path is
+            # unreachable in practice but guarded for safety.
+            return
+        # ``GrB_<Type>_free`` takes a pointer-to-pointer (sets ``*p = NULL``
+        # after free). Synthesize a cell pointing at our handle and call it.
+        free_fn(ffi.new(f"{c_type_name}*", gb_obj))
+
 
 class _BinaryopJitDelegate:
     """Mixin for ops that don't own a JIT kernel; defer introspection to ``binaryop``.
@@ -529,10 +634,9 @@ class _BinaryopJitDelegate:
 
     @_jit_c_info.setter
     def _jit_c_info(self, value):
-        if value is not None:  # pragma: no cover (defensive)
-            raise AttributeError(
-                f"{type(self).__name__} does not own _jit_c_info; set it on its binaryop"
-            )
+        # No-op so ``TypedOpBase.__init__``'s ``self._jit_c_info = None``
+        # slot-init succeeds. The kernel lives on ``binaryop``.
+        pass
 
 
 def _deserialize_parameterized(parameterized_op, args, kwargs):
@@ -543,6 +647,10 @@ class ParameterizedUdf:
     __slots__ = "name", "__call__", "_anonymous", "__weakref__"
     is_positional = False
     _custom_dtype = None
+    # Subclasses set this to the OpBase subclass they parameterize (e.g.,
+    # ``ParameterizedUnaryOp._op_class = UnaryOp``). Assigned after the
+    # OpBase subclass is defined to avoid an import-order cycle.
+    _op_class = None
 
     def __init__(self, name, anonymous):
         self.name = name
@@ -553,6 +661,30 @@ class ParameterizedUdf:
 
     def _call(self, *args, **kwargs):
         raise NotImplementedError
+
+    def __reduce__(self):
+        # The namespace prefix (``unary``, ``binary``, ...) comes from the
+        # OpBase subclass each parameterized op wraps. Standard ops pickle by
+        # name; user-registered ones pickle the reduce tuple and re-register
+        # on load via ``_deserialize`` (which dispatches through ``_op_class``).
+        name = f"{self._op_class._modname}.{self.name}"
+        if not self._anonymous and name in _STANDARD_OPERATOR_NAMES:
+            return name
+        return (self._deserialize, (self.name, self.func, self._anonymous, self._is_udt))
+
+    @classmethod
+    def _deserialize(cls, name, func, anonymous, is_udt=False):
+        """Re-register a parameterized UDF on unpickle, or reuse if already present.
+
+        Shared by the five ``Parameterized*Op`` subclasses; each sets
+        ``_op_class`` to the matching OpBase subclass for the dispatch below.
+        """
+        op_cls = cls._op_class
+        if anonymous:
+            return op_cls.register_anonymous(func, name, parameterized=True, is_udt=is_udt)
+        if (rv := op_cls._find(name)) is not None:
+            return rv
+        return op_cls.register_new(name, func, parameterized=True, is_udt=is_udt)
 
 
 _VARNAMES = tuple(x for x in dir(lib) if x[0] != "_")
@@ -771,8 +903,8 @@ class OpBase:
         """Re-register a named UDF on unpickle, or reuse if already present.
 
         Shared by the five UDF-capable subclasses (UnaryOp, BinaryOp,
-        IndexUnaryOp, SelectOp, IndexBinaryOp), all of which emit the
-        same three-tuple from ``__reduce__``.
+        IndexUnaryOp, SelectOp, IndexBinaryOp), all of which use the
+        default ``__reduce__`` below.
         """
         if (rv := cls._find(name)) is not None:
             return rv
@@ -782,6 +914,22 @@ class OpBase:
     def _deserialize_anon_udf(cls, func, name, is_udt):
         """Re-register an anonymous UDF on unpickle."""
         return cls.register_anonymous(func, name, is_udt=is_udt)
+
+    def __reduce__(self):
+        """Default ``__reduce__`` for UDF-capable subclasses.
+
+        Assumes the instance has ``orig_func`` and ``_is_udt`` attributes (all
+        five UDF-capable subclasses do). ``Monoid``, ``Semiring``, and
+        ``Aggregator`` define their own ``__reduce__`` because their pickle
+        shape differs (they hold a binary op + identity, etc.).
+        """
+        if self._anonymous:
+            if hasattr(self.orig_func, "_parameterized_info"):
+                return (_deserialize_parameterized, self.orig_func._parameterized_info)
+            return (type(self)._deserialize_anon_udf, (self.orig_func, self.name, self._is_udt))
+        if (name := f"{self._modname}.{self.name}") in _STANDARD_OPERATOR_NAMES:
+            return name
+        return (type(self)._deserialize_udf, (self.name, self.orig_func, self._is_udt))
 
     @classmethod
     def _check_supports_udf(cls, method_name):

--- a/graphblas/core/operator/binary.py
+++ b/graphblas/core/operator/binary.py
@@ -32,14 +32,23 @@ from .base import (
     ParameterizedUdf,
     TypedOpBase,
     _call_op,
-    _deserialize_parameterized,
     _hasop,
 )
+
+# Imported unconditionally (plain dict, no numba): ``_compile_udt`` consults it
+# even when numba is absent.
+from .udt_utils import BUILTIN_UDT_BINARY_OPS as _BUILTIN_UDT_BINARY_OPS
 
 if _has_numba:
     import numba
 
-    from .base import _compile_udf_for_udt, _get_udt_wrapper, _resolve_udt_return_type
+    from .base import (
+        _bool_to_int8,
+        _compile_udf_for_udt,
+        _finalize_udt_op,
+        _get_udt_wrapper,
+        _resolve_udt_return_type,
+    )
 if _supports_complex:
     from ...dtypes import FC32, FC64
 
@@ -50,52 +59,17 @@ if _has_numba:
     def _make_udt_comparison(dtype, dtype2, *, is_eq):
         """Build a cfunc-ready wrapper for UDT eq or ne comparison.
 
-        Compares per-leaf with IEEE semantics: a NaN-bearing field always
-        compares unequal, even when two records have bit-identical NaN
-        patterns. Padding bytes are skipped implicitly because we never
-        read them. Returns ``(wrapper_func, wrapper_sig)``.
-
-        Three operand shapes are supported, matching the arithmetic ops:
-
-        - Both sides the same UDT (record or array). They must agree on
-          structure; mixing record vs array or differing field names /
-          array shapes raises ``KeyError``.
-        - One side is a UDT, the other is a plain scalar type. The
-          scalar is broadcast to every leaf (``all(leaf == scalar)`` for
-          ``eq``, ``any(leaf != scalar)`` for ``ne``). This matches the
-          broadcast semantics that ``plus``, ``minus``, ``times``, etc.
-          already provide.
-
-        Without the mixed-type path, the wrapper would dereference the
-        non-UDT operand as if it were a UDT, reading past the cell and
-        silently producing nonsense results.
+        Compares per-leaf with IEEE semantics (NaN compares unequal even
+        to itself); scalar broadcasts to every leaf when paired with a
+        UDT. Mismatched-shape UDT pairs raise ``KeyError``. Returns
+        ``(wrapper_func, wrapper_sig)``.
         """
-        from .udt_utils import _get_udt_info, _iter_record_leaves
+        from .udt_utils import _check_udt_pair, _get_udt_info, _iter_record_leaves
 
         info_x = _get_udt_info(dtype)
         info_y = _get_udt_info(dtype2)
         op_name = "eq" if is_eq else "ne"
-
-        if info_x is not None and info_y is not None:
-            kind_x, detail_x = info_x
-            kind_y, detail_y = info_y
-            if kind_x != kind_y:
-                raise KeyError(
-                    f"binary.{op_name} does not work with ({dtype}, {dtype2}): "
-                    f"cannot mix record and array UDTs in a single element-wise op."
-                )
-            if kind_x == "record" and detail_x != detail_y:
-                raise KeyError(
-                    f"binary.{op_name} does not work with ({dtype}, {dtype2}): "
-                    f"record UDTs must share field names; got {list(detail_x)} vs "
-                    f"{list(detail_y)}."
-                )
-            if kind_x == "array" and detail_x != detail_y:
-                raise KeyError(
-                    f"binary.{op_name} does not work with ({dtype}, {dtype2}): "
-                    f"array UDTs must share base dtype and flat size; "
-                    f"got {detail_x} vs {detail_y}."
-                )
+        _check_udt_pair(op_name, dtype, dtype2, info_x, info_y)
 
         x_is_scalar = info_x is None
         y_is_scalar = info_y is None
@@ -249,6 +223,7 @@ class TypedBuiltinBinaryOp(TypedOpBase):
 class TypedUserBinaryOp(TypedOpBase):
     __slots__ = "_monoid"
     opclass = "BinaryOp"
+    _owns_gb_obj = True
 
     def __init__(self, parent, name, type_, return_type, gb_obj, dtype2=None):
         super().__init__(parent, name, type_, return_type, gb_obj, f"{name}_{type_}", dtype2=dtype2)
@@ -327,20 +302,6 @@ class ParameterizedBinaryOp(ParameterizedUdf):
         return self._commutes_to
 
     is_commutative = TypedBuiltinBinaryOp.is_commutative
-
-    def __reduce__(self):
-        name = f"binary.{self.name}"
-        if not self._anonymous and name in _STANDARD_OPERATOR_NAMES:
-            return name
-        return (self._deserialize, (self.name, self.func, self._anonymous, self._is_udt))
-
-    @staticmethod
-    def _deserialize(name, func, anonymous, is_udt=False):
-        if anonymous:
-            return BinaryOp.register_anonymous(func, name, parameterized=True, is_udt=is_udt)
-        if (rv := BinaryOp._find(name)) is not None:
-            return rv
-        return BinaryOp.register_new(name, func, parameterized=True, is_udt=is_udt)
 
 
 def _floordiv(x, y):
@@ -428,10 +389,10 @@ def _pair_dtype(op, dtype, dtype2):
 
 
 if _has_numba:
-    from .udt_utils import BUILTIN_UDT_BINARY_OPS as _BUILTIN_UDT_BINARY_OPS
     from .udt_utils import (
         _compile_codegen,
         _has_jit_set,
+        _maybe_warn_jit_skipped,
         compile_udt_binary_wrapper,
         set_jit_c_on_op,
     )
@@ -589,15 +550,8 @@ class BinaryOp(OpBase):
                 elif type_ == BOOL and ret_type == INT64 and return_types.get(INT8) == INT8:
                     ret_type = INT8
 
-                # Numba is unable to handle BOOL correctly right now, but we have a workaround
-                # See: https://github.com/numba/numba/issues/5395
-                # We're relying on coercion behaving correctly here.
-                # MAINT 2026-05-17: re-verified on Numba 0.65 (cfunc with
-                # CPointer(boolean) fails to compile: "Storing i8 to ptr of
-                # i1"). Re-test periodically and drop the INT8 routing when
-                # upstream is fixed.
-                input_type = INT8 if type_ == BOOL else type_
-                return_type = INT8 if ret_type == BOOL else ret_type
+                input_type = _bool_to_int8(type_)
+                return_type = _bool_to_int8(ret_type)
 
                 # Build wrapper because GraphBLAS wants pointers and void return
                 wrapper_sig = nt.void(
@@ -693,22 +647,8 @@ class BinaryOp(OpBase):
                 numba_func, ret_type, dtype, dtype2, numba_ret_type=numba_ret_type
             )
 
-        binary_wrapper = numba.cfunc(wrapper_sig, nopython=True)(binary_wrapper)
-        new_binary = ffi_new("GrB_BinaryOp*")
-        check_status_carg(
-            lib.GrB_BinaryOp_new(
-                new_binary, binary_wrapper.cffi, ret_type._carg, dtype._carg, dtype2._carg
-            ),
-            "BinaryOp",
-            new_binary[0],
-        )
-        op = TypedUserBinaryOp(
-            self,
-            self.name,
-            dtype,
-            ret_type,
-            new_binary[0],
-            dtype2=dtype2,
+        op = _finalize_udt_op(
+            self, dtype, dtype2, ret_type, binary_wrapper, wrapper_sig, TypedUserBinaryOp
         )
         # Set JIT C definition for auto-generated built-in UDT ops. Only
         # same-type pairs apply: mixed UDT+scalar ops don't have a
@@ -718,7 +658,7 @@ class BinaryOp(OpBase):
         if _has_numba and _has_jit_set and dtype == dtype2 and is_jittable:
             if self.name in _BUILTIN_UDT_BINARY_OPS:
                 op._jit_c_info = set_jit_c_on_op(
-                    new_binary[0],
+                    op.gb_obj,
                     self.name,
                     _BUILTIN_UDT_BINARY_OPS[self.name],
                     dtype,
@@ -731,20 +671,13 @@ class BinaryOp(OpBase):
                 from .udt_utils import set_jit_c_comparison_on_op
 
                 op._jit_c_info = set_jit_c_comparison_on_op(
-                    new_binary[0],
+                    op.gb_obj,
                     self.name,
                     dtype,
                     lib.GrB_BinaryOp_set_String,
                     is_eq=(self.name == "eq"),
                 )
-            if op._jit_c_info is None:
-                # JIT setup was skipped despite SS supporting JIT generally
-                # (compiler unusable, mode off, or UDT not C-expressible).
-                from ..ss.jit_config import _maybe_warn_no_jit
-
-                _maybe_warn_no_jit(op_name=self.name, dtype_name=dtype.name)
-        self._udt_types[dtypes] = ret_type
-        self._udt_ops[dtypes] = op
+            _maybe_warn_jit_skipped(op._jit_c_info, self.name, dtype.name)
         return op
 
     @classmethod
@@ -1096,15 +1029,6 @@ class BinaryOp(OpBase):
             self._udt_types = {}  # {(dtype, dtype): DataType}
             self._udt_ops = {}  # {(dtype, dtype): TypedUserBinaryOp}
 
-    def __reduce__(self):
-        if self._anonymous:
-            if hasattr(self.orig_func, "_parameterized_info"):
-                return (_deserialize_parameterized, self.orig_func._parameterized_info)
-            return (BinaryOp._deserialize_anon_udf, (self.orig_func, self.name, self._is_udt))
-        if (name := f"binary.{self.name}") in _STANDARD_OPERATOR_NAMES:
-            return name
-        return (BinaryOp._deserialize_udf, (self.name, self.orig_func, self._is_udt))
-
     __call__ = TypedBuiltinBinaryOp.__call__
     is_commutative = TypedBuiltinBinaryOp.is_commutative
     commutes_to = ParameterizedBinaryOp.commutes_to
@@ -1116,3 +1040,6 @@ class BinaryOp(OpBase):
 
             self._monoid = Monoid._find(self.name)
         return self._monoid
+
+
+ParameterizedBinaryOp._op_class = BinaryOp

--- a/graphblas/core/operator/indexbinary.py
+++ b/graphblas/core/operator/indexbinary.py
@@ -6,7 +6,7 @@ from ...dtypes import BOOL, INT8, UINT64, lookup_dtype
 from ...exceptions import UdfParseError, check_status_carg
 from .. import _has_numba, ffi, lib
 from ..dtypes import _sample_values
-from .base import OpBase, ParameterizedUdf, TypedOpBase, _deserialize_parameterized
+from .base import OpBase, ParameterizedUdf, TypedOpBase
 
 _has_idxbinop = hasattr(lib, "GxB_IndexBinaryOp_new")
 
@@ -14,6 +14,7 @@ if _has_numba:
     import numba
 
     from .base import (
+        _bool_to_int8,
         _compile_udf_for_udt,
         _get_udt_wrapper_indexbinary,
         _resolve_udt_return_type,
@@ -37,6 +38,27 @@ def _rebind_indexbinaryop(parent, type_, theta):
     return typed(theta)
 
 
+def _theta_to_scalar(theta, dtype):
+    """Wrap a raw (non-Scalar) theta as a GrB Scalar for binding.
+
+    ``dtype`` is the thunk dtype when known (a UDT thunk or an explicit
+    ``dtype=``), else ``None`` to infer from the value. A raw user-defined-type
+    value (array/tuple) can't be inferred, so raise a clear error that names the
+    value and the working alternatives.
+    """
+    from ..scalar import Scalar
+
+    try:
+        return Scalar.from_value(theta, dtype, is_cscalar=False, name="")  # pragma: is_grbscalar
+    except TypeError as exc:
+        if dtype is None:
+            raise TypeError(
+                f"Cannot infer a dtype for theta from {theta!r}; pass an explicit dtype "
+                "(e.g., op(value, dtype=...)) or a typed Scalar. Required for user-defined types."
+            ) from exc
+        raise
+
+
 class _BoundIndexBinaryOp(TypedOpBase):
     """A BinaryOp produced by binding a theta value to an IndexBinaryOp.
 
@@ -49,9 +71,16 @@ class _BoundIndexBinaryOp(TypedOpBase):
 
     __slots__ = ("_theta",)
     opclass = "BinaryOp"
+    # Each ``iop(theta)`` call allocates a fresh ``GrB_BinaryOp`` via
+    # ``GxB_BinaryOp_new_IndexOp`` and bound IBOs are never cached, so this
+    # is the per-call allocation that ``TypedOpBase.__del__`` must release.
+    # Without this, every ``iop(theta)`` (including each pickle round-trip)
+    # leaks one ``GrB_BinaryOp`` for the life of the process.
+    _owns_gb_obj = True
     # A bound IBO is monomorphic in its operand types (one ``(x, y, z,
     # theta)`` combination). Expose the polymorphism / commutativity
-    # markers that ``Semiring._build`` and related consumers probe as
+    # markers that ``Semiring.__init__``, ``Semiring.is_positional``,
+    # ``Semiring._custom_dtype``, and ``TypedUserSemiring`` probe as
     # class-level defaults, so they get sane answers (and no
     # ``AttributeError``) when a bound IBO is passed in place of a
     # ``BinaryOp`` parent.
@@ -101,11 +130,15 @@ class TypedBuiltinIndexBinaryOp(TypedOpBase):
             theta = False
         theta_value = theta.value if isinstance(theta, Scalar) else theta
         if not isinstance(theta, Scalar):
-            theta = Scalar.from_value(theta, is_cscalar=False, name="")  # pragma: is_grbscalar
+            # A raw value for a UDT thunk carries the thunk dtype; otherwise the
+            # value is inferred (and a raw UDT value raises a clear error).
+            tt = self.thunk_type
+            theta = _theta_to_scalar(theta, tt if tt._is_udt else None)
         elif theta._is_cscalar:
             # fmt: off
-            val = theta.value
-            theta = Scalar.from_value(val, is_cscalar=False, name="")  # pragma: is_grbscalar
+            # Pass dtype explicitly; an array-UDT value would otherwise infer wrong.
+            val, dt = theta.value, theta.dtype
+            theta = Scalar.from_value(val, dt, is_cscalar=False, name="")  # pragma: is_grbscalar
             # fmt: on
         new_binop = ffi_new("GrB_BinaryOp*")
         check_status_carg(
@@ -133,6 +166,7 @@ class TypedBuiltinIndexBinaryOp(TypedOpBase):
 class TypedUserIndexBinaryOp(TypedOpBase):
     __slots__ = ()
     opclass = "IndexBinaryOp"
+    _owns_gb_obj = True
 
     def __init__(self, parent, name, type_, return_type, gb_obj, dtype2=None):
         super().__init__(parent, name, type_, return_type, gb_obj, f"{name}_{type_}", dtype2=dtype2)
@@ -168,20 +202,6 @@ class ParameterizedIndexBinaryOp(ParameterizedUdf):
         idxbinop = self.func(*args, **kwargs)
         idxbinop._parameterized_info = (self, args, kwargs)
         return IndexBinaryOp.register_anonymous(idxbinop, self.name, is_udt=self._is_udt)
-
-    def __reduce__(self):
-        name = f"indexbinary.{self.name}"
-        if not self._anonymous and name in _STANDARD_OPERATOR_NAMES:
-            return name
-        return (self._deserialize, (self.name, self.func, self._anonymous, self._is_udt))
-
-    @staticmethod
-    def _deserialize(name, func, anonymous, is_udt=False):
-        if anonymous:
-            return IndexBinaryOp.register_anonymous(func, name, parameterized=True, is_udt=is_udt)
-        if (rv := IndexBinaryOp._find(name)) is not None:
-            return rv
-        return IndexBinaryOp.register_new(name, func, parameterized=True, is_udt=is_udt)
 
 
 class IndexBinaryOp(OpBase):
@@ -262,14 +282,8 @@ class IndexBinaryOp(OpBase):
                 elif type_ == BOOL and ret_type.name == "INT64" and return_types.get(INT8) == INT8:
                     ret_type = INT8
 
-                # Numba can't handle BOOL correctly (see numba/numba#5395), so
-                # we route booleans through INT8 and rely on coercion at the
-                # wrapper boundary. See the BOOL branches below.
-                # MAINT 2026-05-17: re-verified on Numba 0.65 (cfunc with
-                # CPointer(boolean) fails to compile: "Storing i8 to ptr of
-                # i1"). Re-test periodically.
-                input_type = INT8 if type_ == BOOL else type_
-                return_type = INT8 if ret_type == BOOL else ret_type
+                input_type = _bool_to_int8(type_)
+                return_type = _bool_to_int8(ret_type)
 
                 # Build a wrapper that calls z = f(x, ix, jx, y, iy, jy, theta).
                 # C signature: void(z*, x*, ix, jx, y*, iy, jy, theta*).
@@ -500,18 +514,6 @@ class IndexBinaryOp(OpBase):
             self._udt_types = {}  # {(dtype, dtype2): DataType}
             self._udt_ops = {}  # {(dtype, dtype2): TypedUserIndexBinaryOp}
 
-    def __reduce__(self):
-        if self._anonymous:
-            if hasattr(self.orig_func, "_parameterized_info"):
-                return (_deserialize_parameterized, self.orig_func._parameterized_info)
-            return (
-                IndexBinaryOp._deserialize_anon_udf,
-                (self.orig_func, self.name, self._is_udt),
-            )
-        if (name := f"indexbinary.{self.name}") in _STANDARD_OPERATOR_NAMES:
-            return name
-        return (IndexBinaryOp._deserialize_udf, (self.name, self.orig_func, self._is_udt))
-
     def __call__(self, theta=None, dtype=None):
         """Bind a theta value to produce a BinaryOp.
 
@@ -534,11 +536,14 @@ class IndexBinaryOp(OpBase):
         if theta is None:
             theta = False
         if not isinstance(theta, Scalar):
-            theta = Scalar.from_value(theta, is_cscalar=False, name="")  # pragma: is_grbscalar
+            # An explicit dtype supplies a UDT; with no dtype the value is
+            # inferred (and a raw UDT value raises a clear error).
+            theta = _theta_to_scalar(theta, _lookup_dtype(dtype) if dtype is not None else None)
         elif theta._is_cscalar:
             # fmt: off
-            val = theta.value
-            theta = Scalar.from_value(val, is_cscalar=False, name="")  # pragma: is_grbscalar
+            # Pass dtype explicitly; an array-UDT value would otherwise infer wrong.
+            val, dt = theta.value, theta.dtype
+            theta = Scalar.from_value(val, dt, is_cscalar=False, name="")  # pragma: is_grbscalar
             # fmt: on
         if dtype is None:
             dtype = theta.dtype
@@ -546,3 +551,6 @@ class IndexBinaryOp(OpBase):
             dtype = _lookup_dtype(dtype)
         typed_op = self[dtype]
         return typed_op(theta)
+
+
+ParameterizedIndexBinaryOp._op_class = IndexBinaryOp

--- a/graphblas/core/operator/indexunary.py
+++ b/graphblas/core/operator/indexunary.py
@@ -7,12 +7,18 @@ from ...dtypes import BOOL, FP64, INT8, INT64, UINT64, lookup_dtype
 from ...exceptions import UdfParseError, check_status_carg
 from .. import _has_numba, ffi, lib
 from ..dtypes import _sample_values
-from .base import OpBase, ParameterizedUdf, TypedOpBase, _call_op, _deserialize_parameterized
+from .base import OpBase, ParameterizedUdf, TypedOpBase, _call_op
 
 if _has_numba:
     import numba
 
-    from .base import _compile_udf_for_udt, _get_udt_wrapper, _resolve_udt_return_type
+    from .base import (
+        _bool_to_int8,
+        _compile_udf_for_udt,
+        _finalize_udt_op,
+        _get_udt_wrapper,
+        _resolve_udt_return_type,
+    )
 ffi_new = ffi.new
 
 
@@ -33,6 +39,7 @@ class TypedBuiltinIndexUnaryOp(TypedOpBase):
 class TypedUserIndexUnaryOp(TypedOpBase):
     __slots__ = ()
     opclass = "IndexUnaryOp"
+    _owns_gb_obj = True
 
     def __init__(self, parent, name, type_, return_type, gb_obj, dtype2=None):
         super().__init__(parent, name, type_, return_type, gb_obj, f"{name}_{type_}", dtype2=dtype2)
@@ -64,22 +71,6 @@ class ParameterizedIndexUnaryOp(ParameterizedUdf):
         indexunary = self.func(*args, **kwargs)
         indexunary._parameterized_info = (self, args, kwargs)
         return IndexUnaryOp.register_anonymous(indexunary, self.name, is_udt=self._is_udt)
-
-    def __reduce__(self):
-        # NOT COVERED
-        name = f"indexunary.{self.name}"
-        if not self._anonymous and name in _STANDARD_OPERATOR_NAMES:
-            return name
-        return (self._deserialize, (self.name, self.func, self._anonymous, self._is_udt))
-
-    @staticmethod
-    def _deserialize(name, func, anonymous, is_udt=False):
-        # NOT COVERED
-        if anonymous:
-            return IndexUnaryOp.register_anonymous(func, name, parameterized=True, is_udt=is_udt)
-        if (rv := IndexUnaryOp._find(name)) is not None:
-            return rv
-        return IndexUnaryOp.register_new(name, func, parameterized=True, is_udt=is_udt)
 
 
 class IndexUnaryOp(OpBase):
@@ -152,15 +143,8 @@ class IndexUnaryOp(OpBase):
                 elif type_ == BOOL and ret_type == INT64 and return_types.get(INT8) == INT8:
                     ret_type = INT8
 
-                # Numba is unable to handle BOOL correctly right now, but we have a workaround
-                # See: https://github.com/numba/numba/issues/5395
-                # We're relying on coercion behaving correctly here.
-                # MAINT 2026-05-17: re-verified on Numba 0.65 (cfunc with
-                # CPointer(boolean) fails to compile: "Storing i8 to ptr of
-                # i1"). Re-test periodically and drop the INT8 routing when
-                # upstream is fixed.
-                input_type = INT8 if type_ == BOOL else type_
-                return_type = INT8 if ret_type == BOOL else ret_type
+                input_type = _bool_to_int8(type_)
+                return_type = _bool_to_int8(ret_type)
 
                 # Build wrapper because GraphBLAS wants pointers and void return
                 wrapper_sig = nt.void(
@@ -232,27 +216,9 @@ class IndexUnaryOp(OpBase):
         indexunary_wrapper, wrapper_sig = _get_udt_wrapper(
             numba_func, ret_type, dtype, dtype2, include_indexes=True, numba_ret_type=numba_ret_type
         )
-
-        indexunary_wrapper = numba.cfunc(wrapper_sig, nopython=True)(indexunary_wrapper)
-        new_indexunary = ffi_new("GrB_IndexUnaryOp*")
-        check_status_carg(
-            lib.GrB_IndexUnaryOp_new(
-                new_indexunary, indexunary_wrapper.cffi, ret_type._carg, dtype._carg, dtype2._carg
-            ),
-            "IndexUnaryOp",
-            new_indexunary[0],
+        return _finalize_udt_op(
+            self, dtype, dtype2, ret_type, indexunary_wrapper, wrapper_sig, TypedUserIndexUnaryOp
         )
-        op = TypedUserIndexUnaryOp(
-            self,
-            self.name,
-            dtype,
-            ret_type,
-            new_indexunary[0],
-            dtype2=dtype2,
-        )
-        self._udt_types[dtypes] = ret_type
-        self._udt_ops[dtypes] = op
-        return op
 
     @classmethod
     def register_anonymous(cls, func, name=None, *, parameterized=False, is_udt=False):
@@ -265,8 +231,8 @@ class IndexUnaryOp(OpBase):
         func : FunctionType
             The function to compile. For all current backends, this must be able
             to be compiled with ``numba.njit``.
-            ``func`` takes four input parameters--any dtype, int64, int64,
-            any dtype and returns any dtype. The first argument (any dtype) is
+            ``func`` takes four input parameters (any dtype, int64, int64,
+            any dtype) and returns any dtype. The first argument (any dtype) is
             the value of the input Matrix or Vector, the second argument (int64)
             is the row index of the Matrix or the index of the Vector, the third
             argument (int64) is the column index of the Matrix or 0 for a Vector,
@@ -315,8 +281,8 @@ class IndexUnaryOp(OpBase):
         func : FunctionType
             The function to compile. For all current backends, this must be able
             to be compiled with ``numba.njit``.
-            ``func`` takes four input parameters--any dtype, int64, int64,
-            any dtype and returns any dtype. The first argument (any dtype) is
+            ``func`` takes four input parameters (any dtype, int64, int64,
+            any dtype) and returns any dtype. The first argument (any dtype) is
             the value of the input Matrix or Vector, the second argument (int64)
             is the row index of the Matrix or the index of the Vector, the third
             argument (int64) is the column index of the Matrix or 0 for a Vector,
@@ -435,18 +401,7 @@ class IndexUnaryOp(OpBase):
             self._udt_types = {}  # {dtype: DataType}
             self._udt_ops = {}  # {dtype: TypedUserIndexUnaryOp}
 
-    def __reduce__(self):
-        if self._anonymous:
-            if hasattr(self.orig_func, "_parameterized_info"):
-                # NOT COVERED
-                return (_deserialize_parameterized, self.orig_func._parameterized_info)
-            return (
-                IndexUnaryOp._deserialize_anon_udf,
-                (self.orig_func, self.name, self._is_udt),
-            )
-        if (name := f"indexunary.{self.name}") in _STANDARD_OPERATOR_NAMES:
-            return name
-        # NOT COVERED
-        return (IndexUnaryOp._deserialize_udf, (self.name, self.orig_func, self._is_udt))
-
     __call__ = TypedBuiltinIndexUnaryOp.__call__
+
+
+ParameterizedIndexUnaryOp._op_class = IndexUnaryOp

--- a/graphblas/core/operator/monoid.py
+++ b/graphblas/core/operator/monoid.py
@@ -141,6 +141,11 @@ class TypedUserMonoid(_BinaryopJitDelegate, TypedOpBase):
     __slots__ = "binaryop", "identity"
     opclass = "Monoid"
     is_commutative = True
+    # Deliberately not ``_owns_gb_obj = True``: a ``GrB_Monoid`` holds a
+    # pointer into its underlying ``GrB_BinaryOp``, and Python's cyclic GC
+    # makes no guarantee about which side is finalized first. Freeing the
+    # monoid after its binary op is gone aborts SuiteSparse. The leak is
+    # bounded by the cache in ``Monoid.{_typed_ops,_udt_ops}``.
 
     def __init__(self, parent, name, type_, return_type, gb_obj, binaryop, identity):
         super().__init__(parent, name, type_, return_type, gb_obj, f"{name}_{type_}")
@@ -203,15 +208,18 @@ class ParameterizedMonoid(ParameterizedUdf):
         name = f"monoid.{self.name}"
         if not self._anonymous and name in _STANDARD_OPERATOR_NAMES:  # pragma: no cover
             return name
-        return (self._deserialize, (self.name, self.binaryop, self.identity, self._anonymous))
+        return (
+            self._deserialize,
+            (self.name, self.binaryop, self.identity, self._anonymous, self._is_idempotent),
+        )
 
     @staticmethod
-    def _deserialize(name, binaryop, identity, anonymous):
+    def _deserialize(name, binaryop, identity, anonymous, is_idempotent=False):
         if anonymous:
-            return Monoid.register_anonymous(binaryop, identity, name)
+            return Monoid.register_anonymous(binaryop, identity, name, is_idempotent=is_idempotent)
         if (rv := Monoid._find(name)) is not None:
             return rv
-        return Monoid.register_new(name, binaryop, identity)
+        return Monoid.register_new(name, binaryop, identity, is_idempotent=is_idempotent)
 
 
 class Monoid(OpBase):
@@ -431,11 +439,30 @@ class Monoid(OpBase):
                 self._udt_ops = {}  # {dtype: TypedUserMonoid}
 
     def __reduce__(self):
-        if self._anonymous:
-            return (self.register_anonymous, (self._binaryop, self._identity, self.name))
-        if (name := f"monoid.{self.name}") in _STANDARD_OPERATOR_NAMES:
+        if not self._anonymous and (name := f"monoid.{self.name}") in _STANDARD_OPERATOR_NAMES:
             return name
-        return (self._deserialize, (self.name, self._binaryop, self._identity))
+        # Carry ``is_idempotent`` through pickle: ``register_anonymous`` /
+        # ``register_new`` take it as keyword-only, and the inherited
+        # ``OpBase._deserialize`` can't pass keyword args, so route through a
+        # dedicated deserializer here.
+        return (
+            Monoid._deserialize_named_monoid,
+            (
+                self.name,
+                self._binaryop,
+                self._identity,
+                self._anonymous,
+                self._is_idempotent,
+            ),
+        )
+
+    @staticmethod
+    def _deserialize_named_monoid(name, binaryop, identity, anonymous, is_idempotent):
+        if anonymous:
+            return Monoid.register_anonymous(binaryop, identity, name, is_idempotent=is_idempotent)
+        if (rv := Monoid._find(name)) is not None:
+            return rv
+        return Monoid.register_new(name, binaryop, identity, is_idempotent=is_idempotent)
 
     @property
     def binaryop(self):

--- a/graphblas/core/operator/select.py
+++ b/graphblas/core/operator/select.py
@@ -1,17 +1,13 @@
 import inspect
 
-from ... import _STANDARD_OPERATOR_NAMES, select
+from ... import select
 from ...dtypes import BOOL, UINT64
-from ...exceptions import check_status_carg
-from .. import _has_numba, ffi, lib
-from .base import OpBase, ParameterizedUdf, TypedOpBase, _call_op, _deserialize_parameterized
+from .. import _has_numba
+from .base import OpBase, ParameterizedUdf, TypedOpBase, _call_op
 from .indexunary import IndexUnaryOp, TypedBuiltinIndexUnaryOp
 
 if _has_numba:
-    import numba
-
-    from .base import _compile_udf_for_udt, _get_udt_wrapper
-ffi_new = ffi.new
+    from .base import _compile_udf_for_udt, _finalize_udt_op, _get_udt_wrapper
 
 
 class TypedBuiltinSelectOp(TypedOpBase):
@@ -29,6 +25,7 @@ class TypedBuiltinSelectOp(TypedOpBase):
 class TypedUserSelectOp(TypedOpBase):
     __slots__ = ()
     opclass = "SelectOp"
+    _owns_gb_obj = True  # underlying object is a GrB_IndexUnaryOp
 
     def __init__(self, parent, name, type_, return_type, gb_obj, dtype2=None):
         super().__init__(parent, name, type_, return_type, gb_obj, f"{name}_{type_}", dtype2=dtype2)
@@ -60,22 +57,6 @@ class ParameterizedSelectOp(ParameterizedUdf):
         sel = self.func(*args, **kwargs)
         sel._parameterized_info = (self, args, kwargs)
         return SelectOp.register_anonymous(sel, self.name, is_udt=self._is_udt)
-
-    def __reduce__(self):
-        # NOT COVERED
-        name = f"select.{self.name}"
-        if not self._anonymous and name in _STANDARD_OPERATOR_NAMES:
-            return name
-        return (self._deserialize, (self.name, self.func, self._anonymous, self._is_udt))
-
-    @staticmethod
-    def _deserialize(name, func, anonymous, is_udt=False):
-        # NOT COVERED
-        if anonymous:
-            return SelectOp.register_anonymous(func, name, parameterized=True, is_udt=is_udt)
-        if (rv := SelectOp._find(name)) is not None:
-            return rv
-        return SelectOp.register_new(name, func, parameterized=True, is_udt=is_udt)
 
 
 class SelectOp(OpBase):
@@ -116,6 +97,10 @@ class SelectOp(OpBase):
                     t.return_type,
                     t.gb_obj,
                 )
+                # Aliases the IndexUnaryOp's allocation. The IndexUnaryOp
+                # owns the free; clearing here prevents a double free when
+                # both ends are GC'd.
+                op._owns_gb_obj_inst = False
             else:
                 op = cls._typed_class(
                     obj,
@@ -149,27 +134,9 @@ class SelectOp(OpBase):
         select_wrapper, wrapper_sig = _get_udt_wrapper(
             numba_func, BOOL, dtype, dtype2, include_indexes=True
         )
-
-        select_wrapper = numba.cfunc(wrapper_sig, nopython=True)(select_wrapper)
-        new_select = ffi_new("GrB_IndexUnaryOp*")
-        check_status_carg(
-            lib.GrB_IndexUnaryOp_new(
-                new_select, select_wrapper.cffi, BOOL._carg, dtype._carg, dtype2._carg
-            ),
-            "IndexUnaryOp",
-            new_select[0],
+        return _finalize_udt_op(
+            self, dtype, dtype2, BOOL, select_wrapper, wrapper_sig, TypedUserSelectOp
         )
-        op = TypedUserSelectOp(
-            self,
-            self.name,
-            dtype,
-            BOOL,
-            new_select[0],
-            dtype2=dtype2,
-        )
-        self._udt_types[dtypes] = BOOL
-        self._udt_ops[dtypes] = op
-        return op
 
     @classmethod
     def register_anonymous(cls, func, name=None, *, parameterized=False, is_udt=False):
@@ -183,8 +150,8 @@ class SelectOp(OpBase):
         func : FunctionType
             The function to compile. For all current backends, this must be able
             to be compiled with ``numba.njit``.
-            ``func`` takes four input parameters--any dtype, int64, int64,
-            any dtype and returns boolean. The first argument (any dtype) is
+            ``func`` takes four input parameters (any dtype, int64, int64,
+            any dtype) and returns boolean. The first argument (any dtype) is
             the value of the input Matrix or Vector, the second argument (int64)
             is the row index of the Matrix or the index of the Vector, the third
             argument (int64) is the column index of the Matrix or 0 for a Vector,
@@ -234,8 +201,8 @@ class SelectOp(OpBase):
         func : FunctionType
             The function to compile. For all current backends, this must be able
             to be compiled with ``numba.njit``.
-            ``func`` takes four input parameters--any dtype, int64, int64,
-            any dtype and returns boolean. The first argument (any dtype) is
+            ``func`` takes four input parameters (any dtype, int64, int64,
+            any dtype) and returns boolean. The first argument (any dtype) is
             the value of the input Matrix or Vector, the second argument (int64)
             is the row index of the Matrix or the index of the Vector, the third
             argument (int64) is the column index of the Matrix or 0 for a Vector,
@@ -324,22 +291,10 @@ class SelectOp(OpBase):
         self.is_positional = is_positional
         self._is_udt = is_udt
         if is_udt:
-            # NOT COVERED
             self._udt_types = {}  # {dtype: DataType}
             self._udt_ops = {}  # {dtype: TypedUserIndexUnaryOp}
 
-    def __reduce__(self):
-        if self._anonymous:
-            if hasattr(self.orig_func, "_parameterized_info"):
-                # NOT COVERED
-                return (_deserialize_parameterized, self.orig_func._parameterized_info)
-            return (
-                SelectOp._deserialize_anon_udf,
-                (self.orig_func, self.name, self._is_udt),
-            )
-        if (name := f"select.{self.name}") in _STANDARD_OPERATOR_NAMES:
-            return name
-        # NOT COVERED
-        return (SelectOp._deserialize_udf, (self.name, self.orig_func, self._is_udt))
-
     __call__ = TypedBuiltinSelectOp.__call__
+
+
+ParameterizedSelectOp._op_class = SelectOp

--- a/graphblas/core/operator/semiring.py
+++ b/graphblas/core/operator/semiring.py
@@ -95,6 +95,10 @@ class TypedUserSemiring(_BinaryopJitDelegate, TypedOpBase):
     # ``semi.monoid.jit_c_source``.
     __slots__ = "monoid", "binaryop"
     opclass = "Semiring"
+    # Deliberately not ``_owns_gb_obj = True``: see ``TypedUserMonoid``.
+    # Same ordering hazard: a ``GrB_Semiring`` holds pointers into its
+    # ``GrB_Monoid`` and ``GrB_BinaryOp``, and the cache in
+    # ``Semiring.{_typed_ops,_udt_ops}`` bounds the leak.
 
     def __init__(self, parent, name, type_, return_type, gb_obj, monoid, binaryop, dtype2=None):
         super().__init__(parent, name, type_, return_type, gb_obj, f"{name}_{type_}", dtype2=dtype2)
@@ -229,9 +233,7 @@ class Semiring(OpBase):
         from .indexbinary import _BoundIndexBinaryOp
 
         if isinstance(binaryop, _BoundIndexBinaryOp):
-            return cls._build_from_bound_indexbinary(
-                name, monoid, binaryop, anonymous=anonymous
-            )
+            return cls._build_from_bound_indexbinary(name, monoid, binaryop, anonymous=anonymous)
         if type(binaryop) is not BinaryOp:
             raise TypeError(
                 f"binaryop must be a BinaryOp or a bound IndexBinaryOp "

--- a/graphblas/core/operator/udt_utils.py
+++ b/graphblas/core/operator/udt_utils.py
@@ -308,6 +308,37 @@ def _get_udt_info(dtype):
     return None
 
 
+def _check_udt_pair(op_name, dtype, dtype2, info_x, info_y):
+    """Raise ``KeyError`` if two UDT operands disagree on shape.
+
+    ``info_x`` and ``info_y`` are ``_get_udt_info`` results. When either is
+    ``None`` (one side is a scalar broadcast), no check fires. Without this
+    gate the generated wrapper code raises a cryptic Numba ``TypingError``
+    on the first field access.
+    """
+    if info_x is None or info_y is None:
+        return
+    kind_x, detail_x = info_x
+    kind_y, detail_y = info_y
+    if kind_x != kind_y:
+        raise KeyError(
+            f"binary.{op_name} does not work with ({dtype}, {dtype2}): "
+            f"cannot mix record and array UDTs in a single element-wise op."
+        )
+    if kind_x == "record" and detail_x != detail_y:
+        raise KeyError(
+            f"binary.{op_name} does not work with ({dtype}, {dtype2}): "
+            f"record UDTs must share field names; got {list(detail_x)} vs "
+            f"{list(detail_y)}."
+        )
+    if kind_x == "array" and detail_x != detail_y:
+        raise KeyError(
+            f"binary.{op_name} does not work with ({dtype}, {dtype2}): "
+            f"array UDTs must share base dtype and flat size; "
+            f"got {detail_x} vs {detail_y}."
+        )
+
+
 def _iter_record_leaves(np_type, python_prefix="", c_prefix=""):
     """Yield ``(python_access, c_access, leaf_dtype)`` for each leaf in a record.
 
@@ -483,13 +514,13 @@ def _op_supports_field_dtypes(op_name, np_type):
 if _has_numba:
 
     def _expr_binary(py_op, x_expr, y_expr):
-        """Return a Python expression string for a binary op on two expressions."""
+        """Python-source builder; sibling of :func:`_c_expr_binary` for JIT C."""
         if py_op in _FUNC_BINARY_OPS:
             return f"{py_op}({x_expr}, {y_expr})"
         return f"{x_expr} {py_op} {y_expr}"
 
     def _expr_unary(py_op, operand):
-        """Return a Python expression string for a unary op on a fully-qualified operand."""
+        """Python-source builder; sibling of :func:`_c_expr_unary` for JIT C."""
         if py_op in _FUNC_UNARY_OPS:
             return f"{py_op}({operand})"
         return f"{py_op}{operand}"
@@ -577,8 +608,8 @@ if _has_numba:
         )
         return op_func, sig
 
-    # MAINT: this function, ``compile_udt_unary_wrapper`` below, and
-    # ``_make_jit_c_definition`` all branch on ``kind == "record"`` vs the
+    # MAINT 2026-05-21: this function, ``compile_udt_unary_wrapper`` below,
+    # and ``_make_jit_c_definition`` all branch on ``kind == "record"`` vs the
     # array path with near-identical scaffolding. When a third op family
     # (ternary, indexbinary, ...) needs the same treatment, fold the three
     # into one shape-parametrized helper instead of pasting a third copy.
@@ -602,30 +633,7 @@ if _has_numba:
 
         info_x = _get_udt_info(dtype)
         info_y = _get_udt_info(dtype2)
-
-        # When both sides are UDTs, they must agree on shape. Without this
-        # pre-check, generated code like ``x['a'] + y['a']`` fails inside
-        # Numba with a cryptic TypingError mentioning record-field internals.
-        if info_x is not None and info_y is not None:
-            kind_x, detail_x = info_x
-            kind_y, detail_y = info_y
-            if kind_x != kind_y:
-                raise KeyError(
-                    f"binary.{op_name} does not work with ({dtype}, {dtype2}): "
-                    f"cannot mix record and array UDTs in a single element-wise op."
-                )
-            if kind_x == "record" and detail_x != detail_y:
-                raise KeyError(
-                    f"binary.{op_name} does not work with ({dtype}, {dtype2}): "
-                    f"record UDTs must share field names; got {list(detail_x)} vs "
-                    f"{list(detail_y)}."
-                )
-            if kind_x == "array" and detail_x != detail_y:
-                raise KeyError(
-                    f"binary.{op_name} does not work with ({dtype}, {dtype2}): "
-                    f"array UDTs must share base dtype and flat size; "
-                    f"got {detail_x} vs {detail_y}."
-                )
+        _check_udt_pair(op_name, dtype, dtype2, info_x, info_y)
 
         # Pick the UDT side. Both sides may be UDTs; the pre-check above
         # ensures they share a shape in that case.
@@ -885,8 +893,17 @@ def _make_jit_c_comparison_definition(op_name, dtype, *, is_eq):
     expressed in C. The kernel signature is
     ``void op(_Bool *z, const Udt *x, const Udt *y)``: each leaf field
     contributes a scalar ``==`` (or ``!=``) comparison; record-UDT leaves
-    are chained with ``&&`` (eq) or ``||`` (ne). Array UDTs and array
-    sub-fields unroll their elements at codegen time.
+    are chained with ``&&`` (eq) or ``||`` (ne). Top-level array UDTs unroll
+    their elements at codegen time.
+
+    Array-valued sub-fields inside a record (e.g.
+    ``[("weights", (float64, 3))]``) aren't supported: ``_udt_c_typedef``
+    rejects records with array sub-fields (``NP_TO_C_TYPES`` has no entry
+    for sub-array dtypes), so this function returns ``None`` before
+    iterating leaves in that case. Adding support would mean extending
+    ``_udt_c_typedef`` to emit ``double name[N]`` and ``_make_jit_c_definition``
+    to unroll array sub-fields in arithmetic codegen too; both legs need
+    to land together or the eq/ne path is alone in supporting it.
 
     IEEE NaN propagation comes for free: C ``a == b`` is false when either
     side is NaN, so two records both carrying NaN compare unequal under
@@ -894,9 +911,9 @@ def _make_jit_c_comparison_definition(op_name, dtype, *, is_eq):
     semantic comparison.
     """
     np_type = dtype.np_type
-    if np_type.names is not None and not _is_c_compatible_layout(np_type):
-        return None
     pinned_name = dtype.jit_c_name
+    # ``_udt_c_typedef`` returns None when the numpy layout doesn't match a
+    # C compiler's layout for the same struct.
     typedef_info = _udt_c_typedef(pinned_name or dtype.name, np_type)
     if typedef_info is None:
         return None
@@ -904,30 +921,42 @@ def _make_jit_c_comparison_definition(op_name, dtype, *, is_eq):
     c_name = f"{op_name}_{type_name}"
     op = "==" if is_eq else "!="
     join = " && " if is_eq else " || "
-    terms = []
     if np_type.subdtype is not None:
         # Array UDT: unroll all elements.
         _base, shape = np_type.subdtype
         size = reduce(mul, shape)
         terms = [f"((x->v[{i}]) {op} (y->v[{i}]))" for i in range(size)]
     elif np_type.names is not None:
-        for _py, c_path, leaf_dtype in _iter_record_leaves(np_type):
-            if leaf_dtype.subdtype is not None:
-                # Array-valued sub-field inside a record: unroll its
-                # elements and combine with the same connective.
-                base_dtype, shape = leaf_dtype.subdtype
-                if base_dtype not in NP_TO_C_TYPES:
-                    return None
-                size = reduce(mul, shape)
-                arr_terms = [f"((x->{c_path}[{i}]) {op} (y->{c_path}[{i}]))" for i in range(size)]
-                terms.append("(" + join.join(arr_terms) + ")")
-            else:
-                terms.append(f"((x->{c_path}) {op} (y->{c_path}))")
+        terms = [f"((x->{c}) {op} (y->{c}))" for _py, c, _d in _iter_record_leaves(np_type)]
     else:
         return None
     body = join.join(terms) if terms else ("1" if is_eq else "0")
     params = f"_Bool *z, const {type_name} *x, const {type_name} *y"
     return c_name, f"void {c_name} ({params}) {{ *z = {body} ; }}"
+
+
+def _maybe_warn_jit_skipped(jit_info, op_name, dtype_name):
+    """Emit a ``NoJITWarning`` when JIT setup was skipped despite SS supporting JIT.
+
+    Called by op-class ``_compile_udt`` paths after ``set_jit_c_*_on_op``
+    returns ``None``. The ``_has_jit_set`` gate keeps the warning silent on
+    SS < 8 where JIT is fundamentally absent.
+    """
+    if jit_info is None and _has_jit_set:
+        from ..ss.jit_config import _maybe_warn_no_jit
+
+        _maybe_warn_no_jit(op_name=op_name, dtype_name=dtype_name)
+
+
+def _set_jit_c_strings(gb_obj, c_name, c_defn, set_string_func):
+    """Pin ``GxB_JIT_C_NAME`` + ``GxB_JIT_C_DEFINITION`` on a fresh op handle.
+
+    Both strings are one-shot on SuiteSparse: a second set returns
+    ``GrB_ALREADY_SET`` silently. The return is not checked here because
+    callers always pass a freshly-allocated handle.
+    """
+    set_string_func(gb_obj, ffi.new("char[]", c_name.encode()), lib.GxB_JIT_C_NAME)
+    set_string_func(gb_obj, ffi.new("char[]", c_defn.encode()), lib.GxB_JIT_C_DEFINITION)
 
 
 def set_jit_c_comparison_on_op(gb_obj, op_name, dtype, set_string_func, *, is_eq):
@@ -938,21 +967,14 @@ def set_jit_c_comparison_on_op(gb_obj, op_name, dtype, set_string_func, *, is_eq
     ``(c_name, c_defn)`` on success, ``None`` when JIT isn't available or
     the dtype can't be expressed in C; callers cache the returned strings
     on the op for introspection (see ``TypedUserBinaryOp.jit_c_source``).
-
-    ``gb_obj`` must be a freshly-created ``GrB_BinaryOp``: ``GxB_JIT_C_NAME``
-    and ``GxB_JIT_C_DEFINITION`` are one-shot on SuiteSparse, so a second
-    set returns ``GrB_ALREADY_SET`` silently (the return is not checked
-    here).
     """
     if not _has_jit_set:
         return None
     result = _make_jit_c_comparison_definition(op_name, dtype, is_eq=is_eq)
     if result is None:
         return None
-    c_name, c_defn = result
-    set_string_func(gb_obj, ffi.new("char[]", c_name.encode()), lib.GxB_JIT_C_NAME)
-    set_string_func(gb_obj, ffi.new("char[]", c_defn.encode()), lib.GxB_JIT_C_DEFINITION)
-    return c_name, c_defn
+    _set_jit_c_strings(gb_obj, *result, set_string_func)
+    return result
 
 
 def set_jit_c_on_op(gb_obj, op_name, py_op, dtype, set_string_func, arity=2):
@@ -962,18 +984,11 @@ def set_jit_c_on_op(gb_obj, op_name, py_op, dtype, set_string_func, arity=2):
     dtype is expressible in C, ``None`` otherwise. Callers may cache the
     returned strings for introspection (see ``TypedUserUnaryOp.jit_c_source``
     and ``TypedUserBinaryOp.jit_c_source``).
-
-    ``gb_obj`` must be a freshly-created ``GrB_UnaryOp`` / ``GrB_BinaryOp``:
-    ``GxB_JIT_C_NAME`` and ``GxB_JIT_C_DEFINITION`` are one-shot on
-    SuiteSparse, so a second set returns ``GrB_ALREADY_SET`` silently
-    (the return is not checked here).
     """
     if not _has_jit_set:
         return None
     result = _make_jit_c_definition(op_name, py_op, dtype, arity)
     if result is None:
         return None
-    c_name, c_defn = result
-    set_string_func(gb_obj, ffi.new("char[]", c_name.encode()), lib.GxB_JIT_C_NAME)
-    set_string_func(gb_obj, ffi.new("char[]", c_defn.encode()), lib.GxB_JIT_C_DEFINITION)
-    return c_name, c_defn
+    _set_jit_c_strings(gb_obj, *result, set_string_func)
+    return result

--- a/graphblas/core/operator/unary.py
+++ b/graphblas/core/operator/unary.py
@@ -27,7 +27,6 @@ from .base import (
     OpBase,
     ParameterizedUdf,
     TypedOpBase,
-    _deserialize_parameterized,
     _hasop,
 )
 
@@ -36,7 +35,13 @@ if _supports_complex:
 if _has_numba:
     import numba
 
-    from .base import _compile_udf_for_udt, _get_udt_wrapper, _resolve_udt_return_type
+    from .base import (
+        _bool_to_int8,
+        _compile_udf_for_udt,
+        _finalize_udt_op,
+        _get_udt_wrapper,
+        _resolve_udt_return_type,
+    )
 
 ffi_new = ffi.new
 
@@ -73,6 +78,7 @@ class TypedBuiltinUnaryOp(TypedOpBase):
 class TypedUserUnaryOp(TypedOpBase):
     __slots__ = ()
     opclass = "UnaryOp"
+    _owns_gb_obj = True
 
     def __init__(self, parent, name, type_, return_type, gb_obj):
         super().__init__(parent, name, type_, return_type, gb_obj, f"{name}_{type_}")
@@ -104,20 +110,6 @@ class ParameterizedUnaryOp(ParameterizedUdf):
         unary._parameterized_info = (self, args, kwargs)
         return UnaryOp.register_anonymous(unary, self.name, is_udt=self._is_udt)
 
-    def __reduce__(self):
-        name = f"unary.{self.name}"
-        if not self._anonymous and name in _STANDARD_OPERATOR_NAMES:  # pragma: no cover
-            return name
-        return (self._deserialize, (self.name, self.func, self._anonymous, self._is_udt))
-
-    @staticmethod
-    def _deserialize(name, func, anonymous, is_udt=False):
-        if anonymous:
-            return UnaryOp.register_anonymous(func, name, parameterized=True, is_udt=is_udt)
-        if (rv := UnaryOp._find(name)) is not None:
-            return rv
-        return UnaryOp.register_new(name, func, parameterized=True, is_udt=is_udt)
-
 
 def _identity(x):
     return x  # pragma: no cover (numba)
@@ -129,7 +121,11 @@ def _one(x):
 
 if _has_numba:
     from .udt_utils import BUILTIN_UDT_UNARY_OPS as _BUILTIN_UDT_UNARY_OPS
-    from .udt_utils import _has_jit_set, compile_udt_unary_wrapper, set_jit_c_on_op
+    from .udt_utils import (
+        _maybe_warn_jit_skipped,
+        compile_udt_unary_wrapper,
+        set_jit_c_on_op,
+    )
 
 
 class UnaryOp(OpBase):
@@ -204,15 +200,8 @@ class UnaryOp(OpBase):
                 elif type_ == BOOL and ret_type == INT64 and return_types.get(INT8) == INT8:
                     ret_type = INT8
 
-                # Numba is unable to handle BOOL correctly right now, but we have a workaround
-                # See: https://github.com/numba/numba/issues/5395
-                # We're relying on coercion behaving correctly here.
-                # MAINT 2026-05-17: re-verified on Numba 0.65 (cfunc with
-                # CPointer(boolean) fails to compile: "Storing i8 to ptr of
-                # i1"). Re-test periodically and drop the INT8 routing when
-                # upstream is fixed.
-                input_type = INT8 if type_ == BOOL else type_
-                return_type = INT8 if ret_type == BOOL else ret_type
+                input_type = _bool_to_int8(type_)
+                return_type = _bool_to_int8(ret_type)
 
                 # Build wrapper because GraphBLAS wants pointers and void return
                 wrapper_sig = nt.void(
@@ -272,34 +261,15 @@ class UnaryOp(OpBase):
             unary_wrapper, wrapper_sig, ret_type = compile_udt_unary_wrapper(
                 self.name, py_op, dtype
             )
-            unary_wrapper = numba.cfunc(wrapper_sig, nopython=True)(unary_wrapper)
-            new_unary = ffi_new("GrB_UnaryOp*")
-            check_status_carg(
-                lib.GrB_UnaryOp_new(new_unary, unary_wrapper.cffi, ret_type._carg, dtype._carg),
-                "UnaryOp",
-                new_unary[0],
+            op = _finalize_udt_op(
+                self, dtype, None, ret_type, unary_wrapper, wrapper_sig, TypedUserUnaryOp
             )
-            # ``_has_jit_set`` gates access to ``lib.GrB_UnaryOp_set_String``,
-            # which is absent on SS < 8.
-            if _has_jit_set:
-                jit_info = set_jit_c_on_op(
-                    new_unary[0],
-                    self.name,
-                    py_op,
-                    dtype,
-                    lib.GrB_UnaryOp_set_String,
-                    arity=1,
-                )
-            else:
-                jit_info = None
-            op = TypedUserUnaryOp(self, self.name, dtype, ret_type, new_unary[0])
-            op._jit_c_info = jit_info
-            if jit_info is None and _has_jit_set:
-                from ..ss.jit_config import _maybe_warn_no_jit
-
-                _maybe_warn_no_jit(op_name=self.name, dtype_name=dtype.name)
-            self._udt_types[dtype] = ret_type
-            self._udt_ops[dtype] = op
+            # ``set_jit_c_on_op`` is a no-op (returns None) when
+            # ``_has_jit_set`` is False (SS < 8).
+            op._jit_c_info = set_jit_c_on_op(
+                op.gb_obj, self.name, py_op, dtype, lib.GrB_UnaryOp_set_String, arity=1
+            )
+            _maybe_warn_jit_skipped(op._jit_c_info, self.name, dtype.name)
             return op
         if self._numba_func is None:
             raise KeyError(f"{self.name} does not work with {dtype}")
@@ -309,21 +279,12 @@ class UnaryOp(OpBase):
         _compile_udf_for_udt(numba_func, sig, op_kind="unary", op_name=self.name, dtypes=(dtype,))
         numba_ret_type = numba_func.overloads[sig].signature.return_type
         ret_type = _resolve_udt_return_type(numba_ret_type, dtype)
-
         unary_wrapper, wrapper_sig = _get_udt_wrapper(
             numba_func, ret_type, dtype, numba_ret_type=numba_ret_type
         )
-        unary_wrapper = numba.cfunc(wrapper_sig, nopython=True)(unary_wrapper)
-        new_unary = ffi_new("GrB_UnaryOp*")
-        check_status_carg(
-            lib.GrB_UnaryOp_new(new_unary, unary_wrapper.cffi, ret_type._carg, dtype._carg),
-            "UnaryOp",
-            new_unary[0],
+        return _finalize_udt_op(
+            self, dtype, None, ret_type, unary_wrapper, wrapper_sig, TypedUserUnaryOp
         )
-        op = TypedUserUnaryOp(self, self.name, dtype, ret_type, new_unary[0])
-        self._udt_types[dtype] = ret_type
-        self._udt_ops[dtype] = op
-        return op
 
     @classmethod
     def register_anonymous(cls, func, name=None, *, parameterized=False, is_udt=False):
@@ -522,13 +483,7 @@ class UnaryOp(OpBase):
             self._udt_types = {}  # {dtype: DataType}
             self._udt_ops = {}  # {dtype: TypedUserUnaryOp}
 
-    def __reduce__(self):
-        if self._anonymous:
-            if hasattr(self.orig_func, "_parameterized_info"):
-                return (_deserialize_parameterized, self.orig_func._parameterized_info)
-            return (UnaryOp._deserialize_anon_udf, (self.orig_func, self.name, self._is_udt))
-        if (name := f"unary.{self.name}") in _STANDARD_OPERATOR_NAMES:
-            return name
-        return (UnaryOp._deserialize_udf, (self.name, self.orig_func, self._is_udt))
-
     __call__ = TypedBuiltinUnaryOp.__call__
+
+
+ParameterizedUnaryOp._op_class = UnaryOp

--- a/graphblas/core/scalar.py
+++ b/graphblas/core/scalar.py
@@ -251,6 +251,11 @@ class Scalar(BaseType):
         bool
 
         """
+        if self.dtype._is_udt:
+            raise TypeError(
+                f"Scalar.isclose is not defined for user-defined types (got {self.dtype.name!r}); "
+                "use isequal for exact comparison."
+            )
         if type(other) is not Scalar:
             if other is None:
                 return self._is_empty

--- a/graphblas/core/ss/_utils.py
+++ b/graphblas/core/ss/_utils.py
@@ -1,0 +1,47 @@
+import itertools
+
+from ...exceptions import _error_code_lookup
+from .. import ffi, lib
+from ..dtypes import _string_to_dtype
+
+
+def _resolve_serialized_dtype(data_obj, data_nbytes, obj_kind):
+    """Resolve the dtype of a serialized Matrix/Vector buffer.
+
+    ``GxB_deserialize_type_name`` returns the type's short name (a built-in
+    like ``'INT64'`` or, for a UDT, its ``GxB_JIT_C_NAME``). For UDTs the
+    short name may not match any Python-side registration (e.g., when an
+    anonymous UDT was registered by-shape on the producer side). Fall back
+    to ``GrB_NAME`` (the numpy repr that ``serialize`` writes into the
+    object) when the short name fails to resolve.
+
+    ``obj_kind`` is ``"Matrix"`` or ``"Vector"`` and only shows up in error
+    messages.
+    """
+    cname = ffi.new(f"char[{lib.GxB_MAX_NAME_LEN}]")
+    info = lib.GxB_deserialize_type_name(cname, data_obj, data_nbytes)
+    if info != lib.GrB_SUCCESS:
+        raise _error_code_lookup[info](f"{obj_kind} deserialize failed to get the dtype name")
+    dtype_name = b"".join(itertools.takewhile(b"\x00".__ne__, cname)).decode()
+    orig_error = None
+    if dtype_name:
+        try:
+            return _string_to_dtype(dtype_name)
+        except (ValueError, TypeError, SyntaxError) as exc:
+            orig_error = exc
+    if hasattr(lib, "GxB_Serialized_get_String"):
+        dtype_size = ffi.new("size_t*")
+        info = lib.GxB_Serialized_get_SIZE(data_obj, dtype_size, lib.GrB_NAME, data_nbytes)
+        if info != lib.GrB_SUCCESS:
+            raise _error_code_lookup[info](f"{obj_kind} deserialize failed to get the size of name")
+        dtype_char = ffi.new(f"char[{dtype_size[0]}]")
+        info = lib.GxB_Serialized_get_String(data_obj, dtype_char, lib.GrB_NAME, data_nbytes)
+        if info != lib.GrB_SUCCESS:
+            raise _error_code_lookup[info](f"{obj_kind} deserialize failed to get the name")
+        return _string_to_dtype(ffi.string(dtype_char).decode())
+    # No GrB_NAME fallback available (older SS); surface the original
+    # resolution failure with the actual dtype name attached.
+    raise ValueError(
+        f"{obj_kind} deserialize cannot resolve dtype {dtype_name!r} and "
+        f"GxB_Serialized_get_String is unavailable in this SuiteSparse build"
+    ) from orig_error

--- a/graphblas/core/ss/jit_config.py
+++ b/graphblas/core/ss/jit_config.py
@@ -22,10 +22,22 @@ warning at import or at first JIT use.
 
 import os
 import pathlib
+import platform
 import re
 import subprocess
 
 from .. import lib  # noqa: F401  (sets up cffi)
+
+# Mapping from the values that show up in baked-in ``-arch`` flags to what
+# ``platform.machine()`` returns on the running host.
+_ARCH_ALIASES = {
+    "x86_64": ("x86_64", "amd64"),
+    "arm64": ("arm64", "aarch64"),
+    "aarch64": ("arm64", "aarch64"),
+    "i386": ("i386", "x86"),
+    "ppc": ("ppc", "powerpc"),
+    "ppc64": ("ppc64", "powerpc64"),
+}
 
 
 def _ss_config():
@@ -36,17 +48,16 @@ def _ss_config():
 
 
 def jit_compiler_is_usable():
-    """Return True iff the configured JIT compiler exists on disk.
+    """True iff the configured JIT compiler path exists on disk.
 
-    A cheap probe: it checks the file but doesn't try to compile anything.
-    Use this to decide whether to warn the user or suggest ``fix_jit_config()``.
+    Cheap (no compile attempt); use before suggesting ``fix_jit_config()``.
     """
     cfg = _ss_config()
     cc = cfg.get("jit_c_compiler_name", "")
     return bool(cc) and pathlib.Path(cc).exists()
 
 
-def fix_jit_config(*, use_sysconfig=False, probe=True):
+def fix_jit_config(*, use_sysconfig=True, probe=True):
     """Repair the SuiteSparse:GraphBLAS JIT compiler configuration.
 
     Replaces the baked-in compiler path (which often points at a conda-build
@@ -56,21 +67,24 @@ def fix_jit_config(*, use_sysconfig=False, probe=True):
 
     Parameters
     ----------
-    use_sysconfig : bool, default False
+    use_sysconfig : bool, default True
         When ``$CONDA_PREFIX`` isn't set (pure pip install), try the
-        compiler from ``sysconfig.get_config_var("CC")`` instead.
+        compiler from ``sysconfig.get_config_var("CC")``. Set to ``False``
+        to restrict the repair to a conda environment only.
     probe : bool, default True
         After fixing the config, try to JIT-register a trivial UDT to verify
-        the compiler actually works. If the probe fails, set
-        ``jit_c_control = 'off'`` and return False so SS doesn't keep
-        attempting failing compiles.
+        the compiler actually works. SuiteSparse auto-flips ``jit_c_control``
+        from ``'on'`` to ``'load'`` on a failed compile; the probe absorbs
+        that first failure so user-visible ops afterwards see a stable
+        ``'load'`` (cache-only) state and punt to generic cleanly.
 
     Returns
     -------
     True
         Fix applied and (if ``probe``) verified working.
     False
-        Fix attempted but the probe failed, so JIT is now disabled.
+        Fix attempted but the probe failed. ``jit_c_control`` is now
+        whatever SuiteSparse left it at (typically ``'load'``).
     None
         No environment available to fix from. There's no ``$CONDA_PREFIX``,
         and either ``use_sysconfig=False`` or no sysconfig compiler is set.
@@ -84,12 +98,11 @@ def fix_jit_config(*, use_sysconfig=False, probe=True):
         return None
     if rv is None:
         return None
-    # An explicit user-driven fix is a clean opportunity to re-arm the
-    # one-time ``NoJITWarning``: if the repair worked, the next UDT auto-lift
-    # that *still* falls back to cfunc (different cause: UDT layout, etc.)
+    # An explicit user-driven fix is a clean opportunity to re-arm
+    # ``NoJITWarning``: if the repair worked, the next UDT auto-lift that
+    # *still* falls back to cfunc (different cause: UDT layout, etc.)
     # deserves a fresh notification rather than silent suppression.
-    global _warned_no_jit
-    _warned_no_jit = False
+    _warned_no_jit_for.clear()
     if not probe:
         return True
     return _probe_jit(cfg)
@@ -143,39 +156,70 @@ def _fix_compiler_flags(cfg):
         except (subprocess.CalledProcessError, FileNotFoundError):
             # No Xcode SDK (Linux, or macOS without Xcode CLT).
             flags = re.sub(r"-isysroot\s+\S+", "", flags)
+    flags = _strip_mismatched_arch(flags)
     # Build-time debug path remapping is irrelevant in a user environment.
     flags = re.sub(r"-fdebug-prefix-map=\S+", "", flags)
     cfg["jit_c_compiler_flags"] = flags
 
 
+def _strip_mismatched_arch(flags):
+    """Strip any ``-arch FOO`` that doesn't match the host architecture.
+
+    conda-forge's ``python-suitesparse-graphblas`` bakes the build host's
+    ``-arch`` into ``jit_c_compiler_flags``. On a different host (e.g., an
+    arm64 Mac running an x86_64-built package) the JIT compile produces
+    objects for the wrong arch and the link fails. Leaving the flag out
+    lets the compiler default to the host arch.
+    """
+    host = platform.machine().lower()
+    return re.sub(
+        r"-arch\s+(\S+)",
+        lambda m: "" if m.group(1).lower() not in _ARCH_ALIASES.get(host, (host,)) else m.group(0),
+        flags,
+    )
+
+
 def _probe_jit(cfg):
-    """Probe a trivial JIT compile to verify the config works."""
+    """Probe a trivial JIT compile to verify the config works.
+
+    On failure, SuiteSparse will have flipped ``jit_c_control`` from
+    ``'on'`` to ``'load'`` (its built-in response to a failed compile);
+    we leave that state alone. Both ``'load'`` and ``'off'`` cause
+    downstream ops to punt to the generic kernel, but ``'load'`` preserves
+    any pre-compiled kernels in the cache.
+    """
     from ... import dtypes as _dtypes
 
-    # ``register_new`` rejects a duplicate name with ``ValueError``. The probe
-    # dtype is installed at ``dtypes.ss._jit_probe`` on first success; reuse it
-    # on a second probe so a repeat call doesn't flip ``jit_c_control`` to
-    # ``off``.
+    # The probe dtype is installed at ``dtypes.ss._jit_probe`` on first
+    # success; reuse it on a second probe so a repeat call doesn't appear to
+    # fail. Without the hasattr short-circuit, ``register_new`` would raise
+    # ``ValueError("name unavailable")`` on the second call.
     probe_name = "_jit_probe"
     if hasattr(_dtypes.ss, probe_name):
         return True
     try:
         _dtypes.ss.register_new(probe_name, "typedef struct { int _probe ; } _jit_probe ;")
     except Exception:
-        cfg["jit_c_control"] = "off"
+        # ``register_new`` can raise ``JitError`` (bad path / flags / arch /
+        # SDK), ``RuntimeError`` (SS<8 has no JIT), or one of its input
+        # validation ``ValueError``s. The probe's contract is "did this
+        # work?", so absorb every failure mode here.
         return False
     return True
 
 
 def _auto_fix_jit_at_import():
-    """Auto-fix the JIT config once at ``gb.ss`` import time.
+    """Run :func:`fix_jit_config` at ``gb.ss`` import; designed not to raise.
 
-    When the baked-in compiler path is missing, swap it for one from
-    ``$CONDA_PREFIX/bin/`` or ``sysconfig``, and bump ``jit_c_control`` from
-    the SS default ``'run'`` (load only) to ``'on'`` (compile and load).
-    When the compiler is already usable, only the mode bump applies. Never
-    raises and does not probe; if the resulting state is still broken,
-    ``_maybe_warn_no_jit`` surfaces the issue at first UDT auto-lift.
+    Called unguarded from ``graphblas/ss/__init__.py``, so any exception
+    here breaks ``import graphblas.ss``. The body sticks to dict ops and
+    delegates the failure-prone work to ``_probe_jit``, which catches
+    everything internally.
+
+    The probe is the load-bearing piece: without it, SS would surface
+    ``JitError`` on the first user-triggered JIT compile (a failed
+    compile is only converted to a silent ``'load'`` fallback on
+    subsequent calls).
     """
     cfg = _ss_config()
     if "jit_c_control" not in cfg:
@@ -183,28 +227,30 @@ def _auto_fix_jit_at_import():
     if jit_compiler_is_usable():
         if cfg["jit_c_control"] in ("run", "load"):
             cfg["jit_c_control"] = "on"
-        return
-    try:
+    else:
         fix_jit_config(use_sysconfig=True, probe=False)
-    except Exception:  # pragma: no cover (defensive)
-        return
-    if jit_compiler_is_usable() and cfg["jit_c_control"] in ("run", "load"):
-        cfg["jit_c_control"] = "on"
+        if jit_compiler_is_usable() and cfg["jit_c_control"] in ("run", "load"):
+            cfg["jit_c_control"] = "on"
+    if cfg.get("jit_c_control") == "on":
+        _probe_jit(cfg)
 
 
-_warned_no_jit = False
+# Keyed by ``(op_name, dtype_name)`` so each distinct pair warns once.
+# A user who registers several UDTs gets one warning per (op, dtype) pair
+# rather than a single global swallow.
+_warned_no_jit_for = set()
 
 
 def _maybe_warn_no_jit(*, op_name="", dtype_name=""):
-    """Emit a one-time ``NoJITWarning`` when UDT auto-lift falls back to the cfunc path.
+    """Emit a ``NoJITWarning`` (once per ``(op_name, dtype_name)``) when UDT auto-lift falls back.
 
     The most likely cause (bogus compiler path, ``jit_c_control`` off, or
     UDT not C-expressible) is named in the message along with the remediation.
     """
-    global _warned_no_jit
-    if _warned_no_jit:
+    key = (op_name, dtype_name)
+    if key in _warned_no_jit_for:
         return
-    _warned_no_jit = True
+    _warned_no_jit_for.add(key)
     import warnings as _warnings
 
     cfg = _ss_config()
@@ -214,9 +260,9 @@ def _maybe_warn_no_jit(*, op_name="", dtype_name=""):
             f"({cfg.get('jit_c_compiler_name', '<unset>')!r}); "
             "call ``gb.ss.fix_jit_config()`` to repair it"
         )
-    elif cfg.get("jit_c_control") in ("off", "pause"):
+    elif cfg.get("jit_c_control") != "on":
         cause = (
-            f"jit_c_control is {cfg.get('jit_c_control')!r}; "
+            f"jit_c_control is {cfg.get('jit_c_control')!r} (must be 'on' to compile); "
             "set ``gb.ss.config['jit_c_control'] = 'on'`` to enable compilation"
         )
     else:
@@ -239,7 +285,7 @@ def _maybe_warn_no_jit(*, op_name="", dtype_name=""):
         f"Operations will use the Numba function-pointer fallback "
         f"(typically 2-3x slower for elementwise ops, since SuiteSparse "
         f"can't inline the kernel into its eWise and reduce templates). "
-        f"This warning fires once per process; silence with "
+        f"This warning fires once per (op, dtype) per process; silence with "
         f"``warnings.filterwarnings('ignore', category=gb.exceptions.NoJITWarning)`` "
         f"or by message match.",
         NoJITWarning,

--- a/graphblas/core/ss/matrix.py
+++ b/graphblas/core/ss/matrix.py
@@ -10,7 +10,6 @@ from ...dtypes import _INDEX, BOOL, INT64, UINT64, lookup_dtype
 from ...exceptions import _error_code_lookup, check_status, check_status_carg
 from .. import NULL, _has_numba, ffi, lib
 from ..base import call
-from ..dtypes import _string_to_dtype
 from ..operator import get_typed_op
 from ..scalar import Scalar, _as_scalar, _scalar_index
 from ..utils import (
@@ -25,6 +24,7 @@ from ..utils import (
     values_to_numpy_buffer,
     wrapdoc,
 )
+from ._utils import _resolve_serialized_dtype
 from .config import BaseConfig
 from .descriptor import get_descriptor
 
@@ -4147,52 +4147,7 @@ class ss:
             data = np.frombuffer(data, np.uint8)
         data_obj = ffi.from_buffer("void*", data)
         if dtype is None:
-            # Get the dtype name first (for non-UDTs)
-            cname = ffi_new(f"char[{lib.GxB_MAX_NAME_LEN}]")
-            info = lib.GxB_deserialize_type_name(
-                cname,
-                data_obj,
-                data.nbytes,
-            )
-            if info != lib.GrB_SUCCESS:
-                raise _error_code_lookup[info]("Matrix deserialize failed to get the dtype name")
-            dtype_name = b"".join(itertools.takewhile(b"\x00".__ne__, cname)).decode()
-            # ``dtype_name`` is the type's internal name (a built-in like
-            # ``'INT64'``, or the ``GxB_JIT_C_NAME`` for a UDT). For UDTs
-            # we also fall back to ``GrB_NAME`` (the numpy repr written
-            # into the matrix by ``serialize``) whenever the short name
-            # can't be resolved to a known dtype. That covers UDTs
-            # registered anonymously by-name, where ``JIT_C_NAME`` is set
-            # but no Python-side registration exists under that name.
-            orig_error = None
-            if dtype_name:
-                try:
-                    dtype = _string_to_dtype(dtype_name)
-                except (ValueError, TypeError, SyntaxError) as exc:
-                    orig_error = exc
-            need_fallback = not dtype_name or orig_error is not None
-            if need_fallback and hasattr(lib, "GxB_Serialized_get_String"):
-                dtype_size = ffi_new("size_t*")
-                info = lib.GxB_Serialized_get_SIZE(data_obj, dtype_size, lib.GrB_NAME, data.nbytes)
-                if info != lib.GrB_SUCCESS:
-                    raise _error_code_lookup[info](
-                        "Matrix deserialize failed to get the size of name"
-                    )
-                dtype_char = ffi_new(f"char[{dtype_size[0]}]")
-                info = lib.GxB_Serialized_get_String(
-                    data_obj, dtype_char, lib.GrB_NAME, data.nbytes
-                )
-                if info != lib.GrB_SUCCESS:
-                    raise _error_code_lookup[info]("Matrix deserialize failed to get the name")
-                dtype_name = ffi.string(dtype_char).decode()
-                dtype = _string_to_dtype(dtype_name)
-            elif need_fallback:
-                # No GrB_NAME fallback available (older SS); surface the original
-                # resolution failure with the actual dtype name attached.
-                raise ValueError(
-                    f"Matrix deserialize cannot resolve dtype {dtype_name!r} and "
-                    f"GxB_Serialized_get_String is unavailable in this SuiteSparse build"
-                ) from orig_error
+            dtype = _resolve_serialized_dtype(data_obj, data.nbytes, "Matrix")
         else:
             dtype = lookup_dtype(dtype)
         desc = get_descriptor(**opts)

--- a/graphblas/core/ss/vector.py
+++ b/graphblas/core/ss/vector.py
@@ -10,7 +10,6 @@ from ...dtypes import _INDEX, INT64, UINT64, lookup_dtype
 from ...exceptions import _error_code_lookup, check_status, check_status_carg
 from .. import NULL, ffi, lib
 from ..base import call
-from ..dtypes import _string_to_dtype
 from ..operator import get_typed_op
 from ..scalar import Scalar, _as_scalar
 from ..utils import (
@@ -21,6 +20,7 @@ from ..utils import (
     values_to_numpy_buffer,
     wrapdoc,
 )
+from ._utils import _resolve_serialized_dtype
 from .config import BaseConfig
 from .descriptor import get_descriptor
 from .matrix import _concat_mn, njit
@@ -1718,47 +1718,7 @@ class ss:
             data = np.frombuffer(data, np.uint8)
         data_obj = ffi.from_buffer("void*", data)
         if dtype is None:
-            # Get the dtype name first (for non-UDTs)
-            cname = ffi_new(f"char[{lib.GxB_MAX_NAME_LEN}]")
-            info = lib.GxB_deserialize_type_name(
-                cname,
-                data_obj,
-                data.nbytes,
-            )
-            if info != lib.GrB_SUCCESS:
-                raise _error_code_lookup[info]("Vector deserialize failed to get the dtype name")
-            dtype_name = b"".join(itertools.takewhile(b"\x00".__ne__, cname)).decode()
-            # See ``Matrix.ss.deserialize`` for the rationale: ``dtype_name``
-            # may be a UDT's ``GxB_JIT_C_NAME``, which can't always be
-            # resolved without falling back to ``GrB_NAME`` (the numpy
-            # repr) on the matrix or vector.
-            orig_error = None
-            if dtype_name:
-                try:
-                    dtype = _string_to_dtype(dtype_name)
-                except (ValueError, TypeError, SyntaxError) as exc:
-                    orig_error = exc
-            need_fallback = not dtype_name or orig_error is not None
-            if need_fallback and hasattr(lib, "GxB_Serialized_get_String"):
-                dtype_size = ffi_new("size_t*")
-                info = lib.GxB_Serialized_get_SIZE(data_obj, dtype_size, lib.GrB_NAME, data.nbytes)
-                if info != lib.GrB_SUCCESS:
-                    raise _error_code_lookup[info](
-                        "Vector deserialize failed to get the size of name"
-                    )
-                dtype_char = ffi_new(f"char[{dtype_size[0]}]")
-                info = lib.GxB_Serialized_get_String(
-                    data_obj, dtype_char, lib.GrB_NAME, data.nbytes
-                )
-                if info != lib.GrB_SUCCESS:
-                    raise _error_code_lookup[info]("Vector deserialize failed to get the name")
-                dtype_name = ffi.string(dtype_char).decode()
-                dtype = _string_to_dtype(dtype_name)
-            elif need_fallback:
-                raise ValueError(
-                    f"Vector deserialize cannot resolve dtype {dtype_name!r} and "
-                    f"GxB_Serialized_get_String is unavailable in this SuiteSparse build"
-                ) from orig_error
+            dtype = _resolve_serialized_dtype(data_obj, data.nbytes, "Vector")
         else:
             dtype = lookup_dtype(dtype)
         desc = get_descriptor(**opts)

--- a/graphblas/exceptions.py
+++ b/graphblas/exceptions.py
@@ -107,10 +107,12 @@ class UdfParseError(GraphblasException):
 class NoJITWarning(UserWarning):
     """Auto-lifted UDT op fell back to the Numba cfunc path.
 
-    Emitted once per process from :func:`graphblas.core.ss.jit_config._maybe_warn_no_jit`
-    when an op like ``binary.plus[udt]`` would otherwise have JIT-compiled, but
-    couldn't because the JIT compiler is unusable, ``jit_c_control`` is off, or
-    the UDT isn't expressible as a C struct.
+    Emitted from :func:`graphblas.core.ss.jit_config._maybe_warn_no_jit`
+    when an op like ``binary.plus[udt]`` would otherwise have JIT-compiled,
+    but couldn't because the JIT compiler is unusable, ``jit_c_control``
+    is off, or the UDT isn't expressible as a C struct. Fires once per
+    ``(op, dtype)`` pair per process, so a user who registers several
+    UDTs gets one warning per pair regardless of cause.
 
     Inherits from :class:`UserWarning` so existing ``UserWarning`` filters
     still match it; users can also filter by category for a tight scope:

--- a/graphblas/ss/_core.py
+++ b/graphblas/ss/_core.py
@@ -128,14 +128,14 @@ class GlobalConfig(BaseConfig):
     print_1based : bool
     gpu_control : str, {"always", "never"}
         Only available for SuiteSparse:GraphBLAS 7
-        **GPU support is a work in progress--not recommended to use**
+        **GPU support is a work in progress; not recommended to use**
     gpu_chunk : double
         Only available for SuiteSparse:GraphBLAS 7
-        **GPU support is a work in progress--not recommended to use**
+        **GPU support is a work in progress; not recommended to use**
     gpu_id : int
         Which GPU to use; default is -1, which means do not run on the GPU.
         Only available for SuiteSparse:GraphBLAS >=8
-        **GPU support is a work in progress--not recommended to use**
+        **GPU support is a work in progress; not recommended to use**
     jit_c_control : {"off", "pause", "run", "load", "on}
         Control the CPU JIT:
         "off" : do not use the JIT and free all JIT kernels if loaded

--- a/graphblas/tests/conftest.py
+++ b/graphblas/tests/conftest.py
@@ -2,6 +2,7 @@ import atexit
 import contextlib
 import functools
 import itertools
+import os
 import platform
 import sys
 from pathlib import Path
@@ -12,6 +13,44 @@ import pytest
 import graphblas as gb
 from graphblas.core import _supports_udfs as supports_udfs
 
+# Under ``pytest -n`` (xdist), give each worker its own ``GRAPHBLAS_CACHE_PATH``
+# so concurrent JIT compiles within a single session don't race on the same
+# ``.c``/``.dylib`` paths. SuiteSparse reads this env var at first GraphBLAS
+# init; it must be set before that init runs, or SS takes the unset
+# (HOME-derived) default. ``import graphblas`` above does not trigger
+# init (it's lazy), so setting it here is in time.
+#
+# The path is stable per worker id (``gw0``, ``gw1``, ...) and persistent
+# across pytest invocations (not session-scoped). This way the JIT cache
+# builds up over successive runs and most kernels are dlopen'd instead of
+# recompiled. Total disk footprint is bounded by the number of unique kernels
+# the suite touches across all worker assignments (roughly a few hundred
+# ``.dylib`` files, low tens of MB).
+#
+# Caveat: two ``pytest -n`` invocations running simultaneously would both
+# write to ``gw0/`` etc. and can race on shared kernels. We accept that
+# occasional concurrent-run failure rather than reintroducing per-session
+# isolation, which would defeat cache reuse.
+if (
+    _xdist_worker := os.environ.get("PYTEST_XDIST_WORKER")
+) and "GRAPHBLAS_CACHE_PATH" not in os.environ:
+    _home = os.environ.get("HOME") or os.environ.get("LOCALAPPDATA") or str(Path.cwd())
+    os.environ["GRAPHBLAS_CACHE_PATH"] = str(Path(_home) / ".SuiteSparse_xdist" / _xdist_worker)
+
+# Several ``test_formatting.py`` tests assert verbatim against a Matrix /
+# Vector ``repr()``, and those reprs are produced via pandas. With pandas'
+# default ``display.max_columns = 0`` (terminal mode), pandas auto-fits to
+# ``shutil.get_terminal_size()``, which reads the ``COLUMNS`` env var. When
+# pytest is invoked from a wide terminal the workers inherit ``COLUMNS=<wide>``
+# and pandas renders extra columns that the tests expected to be elided to
+# ``...``. Drop ``COLUMNS`` here so terminal-size detection falls back to the
+# 80x24 default the test expectations were written for. The pop has to run at
+# conftest module load, before any worker imports pandas and before xdist
+# forks. Setting ``display.width`` alone doesn't help; the terminal-size
+# branch is taken whenever ``max_columns == 0``.
+os.environ.pop("COLUMNS", None)
+
+
 orig_binaryops = set()
 orig_semirings = set()
 
@@ -19,7 +58,22 @@ pypy = platform.python_implementation() == "PyPy"
 
 
 def pytest_configure(config):
-    rng = np.random.default_rng()
+    # Under ``pytest -n`` (xdist), every worker imports this conftest and
+    # calls ``pytest_configure`` independently. A fresh ``default_rng()`` in
+    # each worker would pick different backend / blocking / mapnumpy values,
+    # so the workers collect different tests (vanilla skips ``test_ssjit``
+    # etc.) and xdist aborts with "Different tests were collected between
+    # gw0 and gw2." Seed once on the controller and propagate to workers via
+    # an env var; workers inherit it at spawn and derive identical choices.
+    # Set the env var unconditionally on the controller so reproducing a
+    # specific session is just ``GRAPHBLAS_TEST_SEED=<n> pytest ...``.
+    seed_str = os.environ.get("GRAPHBLAS_TEST_SEED")
+    if seed_str is None:
+        seed = int.from_bytes(os.urandom(8), "big")
+        os.environ["GRAPHBLAS_TEST_SEED"] = str(seed)
+    else:
+        seed = int(seed_str)
+    rng = np.random.default_rng(seed)
     randomly = config.getoption("--randomly", None)
     if randomly is None:  # pragma: no cover
         options_unavailable = True
@@ -52,7 +106,7 @@ def pytest_configure(config):
     gb.init(backend, blocking=blocking)
     print(
         f"Running tests with {backend!r} backend, blocking={blocking}, "
-        f"record={record}, mapnumpy={mapnumpy}, runslow={runslow}"
+        f"record={record}, mapnumpy={mapnumpy}, runslow={runslow}, seed={seed}"
     )
     if record:
         rec = gb.Recorder()

--- a/graphblas/tests/test_dtype.py
+++ b/graphblas/tests/test_dtype.py
@@ -327,7 +327,7 @@ def test_udt_with_macro_field_name_falls_back_to_cfunc():
     assert udt.jit_c_name is None
     assert udt.jit_c_definition is None
 
-    jit_config._warned_no_jit = False
+    jit_config._warned_no_jit_for.discard(("plus", udt.name))
     with pytest.warns(NoJITWarning, match="without JIT"):
         plus_udt = gb.binary.plus[udt]
     assert plus_udt.jit_c_source is None
@@ -348,9 +348,10 @@ def test_udt_with_c_reserved_field_name_falls_back_to_cfunc():
     assert udt.jit_c_name is None
     assert udt.jit_c_definition is None
 
-    # Auto-lift must succeed and emit the one-time warning. Reset the
-    # warned-flag so this test sees the warning regardless of test ordering.
-    jit_config._warned_no_jit = False
+    # Auto-lift must succeed and emit a warning. Discard the keyed entry so
+    # this test sees the warning regardless of test ordering (the same
+    # ``(op, dtype)`` may have been warned about in an earlier test).
+    jit_config._warned_no_jit_for.discard(("plus", udt.name))
     with pytest.warns(NoJITWarning, match="without JIT"):
         plus_udt = gb.binary.plus[udt]
     assert plus_udt.jit_c_source is None  # no JIT
@@ -416,6 +417,28 @@ def test_dtype_to_from_string():
                 lookup_dtype(dtype)
         else:
             assert dtype == dtype2
+
+
+def test_dtype_to_string_aligned_outer_packed_inner():
+    """Regression: nested dtype with ``align=True`` outer and a packed inner
+    used to fail ``_dtype_to_string`` round-trip with ``ValueError: Unable
+    to reliably convert dtype to string and back``. Numpy's reconstruction
+    from ``str(np_type)`` enforces the outer's alignment on the inner,
+    rejecting the packed inner's offset. The explicit-offsets fallback
+    encodes the layout verbatim and round-trips cleanly.
+    """
+    packed_inner = np.dtype([("inner_a", np.int32), ("inner_b", np.float64)])
+    outer = np.dtype([("flag", np.int32), ("coord", packed_inner)], align=True)
+    s = core.dtypes._dtype_to_string(outer)
+    rt = core.dtypes._string_to_dtype(s)
+    # The DataType wraps an np.dtype; check the underlying layout matches.
+    rt_np = rt.np_type
+    assert rt_np == outer
+    assert outer.fields["flag"] == rt_np.fields["flag"]
+    assert outer.fields["coord"] == rt_np.fields["coord"]
+    # Registration through register_anonymous used to raise on this shape.
+    udt = dtypes.register_anonymous(outer, "_NestedAlignPacked")
+    assert udt.np_type == outer
 
 
 def test_has_complex():

--- a/graphblas/tests/test_formatting.py
+++ b/graphblas/tests/test_formatting.py
@@ -81,6 +81,17 @@ def html_printer(x, name="", indent=4):
     return _printer(repr_html(x), name, "repr_html", indent)
 
 
+@pytest.fixture(autouse=True)
+def _stable_repr_width(monkeypatch):
+    """Pin terminal width so pandas-rendered reprs are deterministic.
+
+    Matrix/Vector reprs let pandas truncate columns to the terminal width, and
+    the expected strings assume 80. Under ``pytest -n`` workers inherit the
+    launching terminal's width, so a wide terminal would show extra columns.
+    """
+    monkeypatch.setenv("COLUMNS", "80")
+
+
 @pytest.fixture
 def A():
     return Matrix.from_coo([0, 0, 0], [0, 2, 4], [0, 1, 2], nrows=1, ncols=5, name="A_1")

--- a/graphblas/tests/test_indexbinary.py
+++ b/graphblas/tests/test_indexbinary.py
@@ -192,29 +192,42 @@ def test_parameterized():
     assert C.to_coo()[2][0] == 26  # (3+5)*2 + 10 = 26
 
 
-def _pickle_test_add_theta(x, ix, jx, y, iy, jy, theta):  # pragma: no cover (numba)
-    # Module-level so pickle can serialize the function reference. IBO
-    # ``__reduce__`` for user-registered ops returns a tuple containing the
-    # original function; pickling that needs the function to be globally
-    # importable (i.e., not a closure / local function).
+# Module-level so pickle can serialize the function reference. IBO
+# ``__reduce__`` for user-registered ops returns a tuple containing the
+# original function; pickling needs the function to be globally importable
+# (i.e., not a closure / local function).
+def _ibo_add_theta(x, ix, jx, y, iy, jy, theta):  # pragma: no cover (numba)
     return x + y + theta
 
 
+def _ibo_return_x(x, ix, jx, y, iy, jy, theta):  # pragma: no cover (numba)
+    return x
+
+
 def test_pickle_registered():
-    indexbinary.register_new("pickle_test_op", _pickle_test_add_theta)
-    op = indexbinary.pickle_test_op
-    op2 = pickle.loads(pickle.dumps(op))
-    assert op2.name == op.name
+    indexbinary.register_new("pickle_test_op", _ibo_add_theta)
+    try:
+        op = indexbinary.pickle_test_op
+        op2 = pickle.loads(pickle.dumps(op))
+        assert op2.name == op.name
 
-    typed = op[int]
-    typed2 = pickle.loads(pickle.dumps(typed))
-    assert typed2.name == typed.name
+        typed = op[int]
+        typed2 = pickle.loads(pickle.dumps(typed))
+        assert typed2.name == typed.name
 
-    delattr(indexbinary, "pickle_test_op")
+        # Unpickled op must actually run, not just carry the right name.
+        bound = op2[int](7)
+        A = Matrix.from_coo([0, 1], [0, 1], [3, 11])
+        B = Matrix.from_coo([0, 1], [0, 1], [5, 1])
+        C = A.ewise_mult(B, bound).new()
+        # (3+5)+7 = 15; (11+1)+7 = 19
+        assert C.isequal(Matrix.from_coo([0, 1], [0, 1], [15, 19]))
+    finally:
+        delattr(indexbinary, "pickle_test_op")
 
 
 def test_pickle_bound():
-    indexbinary.register_new("pickle_bound_test_op", _pickle_test_add_theta)
+    indexbinary.register_new("pickle_bound_test_op", _ibo_add_theta)
     try:
         bound = indexbinary.pickle_bound_test_op[int](7)
         bound2 = pickle.loads(pickle.dumps(bound))
@@ -226,11 +239,6 @@ def test_pickle_bound():
         assert C1.isequal(C2)
     finally:
         delattr(indexbinary, "pickle_bound_test_op")
-
-
-def _pickle_test_array_udt_theta(x, ix, jx, y, iy, jy, theta):  # pragma: no cover (numba)
-    # Module-level so pickle.dumps(bound) can resolve the orig_func.
-    return x
 
 
 def test_pickle_bound_array_udt_theta():
@@ -246,7 +254,7 @@ def test_pickle_bound_array_udt_theta():
     from graphblas import dtypes
 
     arr_udt = dtypes.register_anonymous(np.dtype((np.int64, (3,))), "_BoundIboArr3")
-    indexbinary.register_new("pickle_bound_array_udt_op", _pickle_test_array_udt_theta, is_udt=True)
+    indexbinary.register_new("pickle_bound_array_udt_op", _ibo_return_x, is_udt=True)
     try:
         op = indexbinary.pickle_bound_array_udt_op
         theta_scalar = gb.Scalar(arr_udt)
@@ -264,24 +272,144 @@ def test_pickle_bound_array_udt_theta():
         delattr(indexbinary, "pickle_bound_array_udt_op")
 
 
+def test_bind_raw_array_udt_theta():
+    """A raw (non-Scalar) array-UDT theta is bound using the known thunk dtype.
+
+    Regression: the ``not isinstance(theta, Scalar)`` branch of the IBO
+    ``__call__`` passed the raw value to ``Scalar.from_value`` with no dtype,
+    which inferred a scalar element type and crashed on the multi-dim ndarray.
+    The typed op now supplies its thunk dtype; the untyped op uses the explicit
+    ``dtype=`` argument.
+    """
+    from graphblas import dtypes
+
+    arr_udt = dtypes.register_anonymous(np.dtype((np.int64, (3,))), "_RawThetaArr3")
+    indexbinary.register_new("raw_array_udt_op", _ibo_return_x, is_udt=True)
+    try:
+        op = indexbinary.raw_array_udt_op
+        raw = np.array([1, 2, 3], dtype=np.int64)
+        # Typed op: ``op[arr_udt]`` knows the thunk dtype.
+        bound = op[arr_udt](raw)
+        assert bound.type is arr_udt
+        assert np.array_equal(bound._theta, raw)
+        # Untyped op: the explicit ``dtype=`` supplies the UDT.
+        bound2 = op(raw, dtype=arr_udt)
+        assert bound2.type is arr_udt
+        assert np.array_equal(bound2._theta, raw)
+    finally:
+        delattr(indexbinary, "raw_array_udt_op")
+
+
+def test_bind_raw_udt_theta_without_dtype_errors():
+    """A raw UDT theta with no dtype can't be inferred; the error is clear and actionable."""
+    indexbinary.register_new("raw_no_dtype_op", _ibo_return_x, is_udt=True)
+    try:
+        op = indexbinary.raw_no_dtype_op
+        with pytest.raises(TypeError, match="Cannot infer a dtype for theta"):
+            op(np.array([1, 2, 3], dtype=np.int64))
+        with pytest.raises(TypeError, match="Cannot infer a dtype for theta"):
+            op((1, 2, 3))
+    finally:
+        delattr(indexbinary, "raw_no_dtype_op")
+
+
+def test_pickle_bound_record_udt_theta():
+    """Bound IBO with a record-UDT theta value round-trips through pickle.
+
+    Companion to :func:`test_pickle_bound_array_udt_theta` for the record
+    flavor of UDT; the array case was the one that crashed before the
+    ``_rebind_indexbinaryop`` Scalar-wrap fix, and the record case worked
+    only because ``_theta`` happened to be a 0-d ``np.void`` that
+    ``Scalar.value =`` accepted. Pin the contract for both shapes so a
+    regression in either is loud.
+    """
+    from graphblas import dtypes
+
+    rec_udt = dtypes.register_anonymous(
+        np.dtype([("a", np.int64), ("b", np.int64)], align=True),
+        "_BoundIboRec",
+    )
+    indexbinary.register_new("pickle_bound_record_udt_op", _ibo_return_x, is_udt=True)
+    try:
+        op = indexbinary.pickle_bound_record_udt_op
+        theta_scalar = gb.Scalar(rec_udt)
+        theta_scalar.value = (5, 7)
+        bound = op[rec_udt](theta_scalar)
+        bound2 = pickle.loads(pickle.dumps(bound))
+        assert tuple(bound2._theta) == (5, 7)
+        assert bound2.parent is bound.parent
+        assert bound2.type is rec_udt
+    finally:
+        delattr(indexbinary, "pickle_bound_record_udt_op")
+
+
+@pytest.mark.slow
+def test_bound_ibo_memory_bounded():
+    """Regression: ``iop(theta)`` used to leak one ``GrB_BinaryOp`` per call.
+
+    Bound IBOs are never cached, so a loop that re-binds with different
+    theta values leaks unboundedly without the ``TypedOpBase.__del__`` free.
+    50k bound IBOs are well above the noise floor for the leak (each is
+    several hundred bytes of SS state plus a python-level wrapper); RSS
+    growth should stay below a few MB after GC drops them.
+    """
+    import gc
+    import resource
+    import sys
+
+    if hasattr(indexbinary, "leak_test_bound_ibo_op"):
+        delattr(indexbinary, "leak_test_bound_ibo_op")
+    indexbinary.register_new("leak_test_bound_ibo_op", _ibo_add_theta)
+    op = indexbinary.leak_test_bound_ibo_op
+    try:
+        # ``ru_maxrss`` is bytes on macOS, KB on Linux.
+        scale = 1024 if sys.platform.startswith("linux") else 1024 * 1024
+
+        def rss_mb():
+            return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / scale
+
+        # Warm up to populate typed-op cache; first call also touches the
+        # numba sample-types path.
+        for _ in range(100):
+            _ = op[int](0)
+        gc.collect()
+        before = rss_mb()
+        for i in range(50_000):
+            _ = op[int](i)
+        gc.collect()
+        after = rss_mb()
+        # 50k leaked GrB_BinaryOps were on the order of tens of MB before the
+        # fix; under the fix we expect single-digit MB.
+        assert (
+            after - before
+        ) < 25.0, f"bound-IBO leak: RSS grew {after - before:.1f} MB over 50k binds"
+    finally:
+        delattr(indexbinary, "leak_test_bound_ibo_op")
+
+
 def test_bound_ibo_jit_introspection_returns_none():
     """Bound IBOs are user-defined and don't go through the built-in JIT C
     codegen path, so the introspection properties must report ``None``
     without crashing. Regression for an earlier construction path that
     used ``__new__`` directly and skipped the inherited ``_jit_c_info``
-    slot's default-None initialization.
+    slot's default-None initialization. Also checks the unpickled instance,
+    which goes through a different construction path (``_rebind_indexbinaryop``
+    -> ``TypedBuiltinIndexBinaryOp.__call__``).
     """
-
-    def add_theta(x, ix, jx, y, iy, jy, theta):  # pragma: no cover (numba)
-        return x + y + theta
-
-    op = indexbinary.register_anonymous(add_theta)
-    bound = op[int](3)
-    # User IBOs don't go through the built-in JIT C codegen path, so these
-    # are expected to be ``None``; the introspection properties must not
-    # crash either way.
-    assert bound.jit_c_name is None
-    assert bound.jit_c_source is None
+    indexbinary.register_new("_jit_introspect_test_op", _ibo_add_theta)
+    try:
+        op = indexbinary._jit_introspect_test_op
+        bound = op[int](3)
+        # User IBOs don't go through the built-in JIT C codegen path, so these
+        # are expected to be ``None``; the introspection properties must not
+        # crash either way.
+        assert bound.jit_c_name is None
+        assert bound.jit_c_source is None
+        bound2 = pickle.loads(pickle.dumps(bound))
+        assert bound2.jit_c_name is None
+        assert bound2.jit_c_source is None
+    finally:
+        delattr(indexbinary, "_jit_introspect_test_op")
 
 
 def test_bad_udf():

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -1886,7 +1886,7 @@ def test_transpose_exceptional():
     with pytest.raises(TypeError, match="not callable"):
         B.T()[1, 0] << 10
     # with pytest.raises(AttributeError):
-    # should use new instead--Now okay.
+    # should use new instead. Now okay.
     assert B.T.dup().isequal(B.T.new())
     # Not exceptional, but while we're here...
     C = B.T.new(mask=A.V)
@@ -2837,7 +2837,7 @@ def test_auto(A, v):
             # print(type(expr).__name__, method)
             val1 = getattr(expected, method)(expected).new()
             if method in {"__or__", "__ror__"} and type(expr) is MatrixEwiseMultExpr:
-                # Doing e.g. `plus(A & B | C)` isn't allowed--make user be explicit
+                # Doing e.g. `plus(A & B | C)` isn't allowed; make user be explicit
                 with pytest.raises(TypeError):
                     val2 = getattr(expected, method)(expr)
                 with pytest.raises(TypeError):

--- a/graphblas/tests/test_op.py
+++ b/graphblas/tests/test_op.py
@@ -1361,7 +1361,6 @@ def test_udt():
 @pytest.mark.skipif("not supports_udfs")
 @pytest.mark.slow
 def test_udt_tuple_return_binaryop(record_udt):
-    """A BinaryOp UDF returning a tuple builds the result UDT field-by-field."""
     v, w = _record_pair(record_udt)
 
     def _add_udt(x, y):
@@ -1377,7 +1376,6 @@ def test_udt_tuple_return_binaryop(record_udt):
 @pytest.mark.skipif("not supports_udfs")
 @pytest.mark.slow
 def test_udt_tuple_return_unaryop_vector(record_udt):
-    """A UnaryOp UDF returning a tuple builds the result UDT field-by-field on a Vector."""
     v, _ = _record_pair(record_udt)
 
     def _double_udt(val):
@@ -1393,7 +1391,6 @@ def test_udt_tuple_return_unaryop_vector(record_udt):
 @pytest.mark.skipif("not supports_udfs")
 @pytest.mark.slow
 def test_udt_tuple_return_unaryop_matrix(record_udt):
-    """A tuple-returning UnaryOp also works on a Matrix.apply path."""
 
     def _double_udt(val):
         return (val["a"] * 2, val["b"] * 2.0)  # pragma: no cover (numba)
@@ -1447,7 +1444,6 @@ def test_udt_tuple_return_semiring(record_udt):
 @pytest.mark.skipif("not supports_udfs")
 @pytest.mark.slow
 def test_udt_tuple_return_indexunary(record_udt):
-    """An IndexUnaryOp UDF returning a tuple builds the result UDT field-by-field."""
     v, _ = _record_pair(record_udt)
 
     def _idx_udt(val, idx, _col, thunk):
@@ -1463,7 +1459,7 @@ def test_udt_tuple_return_indexunary(record_udt):
 @pytest.mark.skipif("not supports_udfs")
 @pytest.mark.slow
 def test_udt_tuple_return_3field():
-    """Tuple-return scales beyond the standard 2-field record dtype."""
+    """Tuple-return works for records with more than two fields."""
     dtype3 = np.dtype([("x", np.int32), ("y", np.float64), ("z", np.int64)], align=True)
     udt3 = dtypes.register_anonymous(dtype3)
     v3 = Vector(udt3, size=2)
@@ -1496,6 +1492,8 @@ def test_udt_input_with_scalar_return(record_udt):
     sum_op = BinaryOp.register_anonymous(_sum_fields, "test_sum_fields", is_udt=True)
     result = sum_op(v & w).new()
     assert result[0].new() == 21.0  # 1 + 20.0
+    assert result[1].new() == 43.0  # 3 + 40.0
+    assert result[2].new() == 65.0  # 5 + 60.0
 
 
 @pytest.mark.skipif("not supports_udfs")
@@ -1615,7 +1613,6 @@ def test_udt_builtin_minmax_record(record_udt, op_name, expected_rows):
 @pytest.mark.skipif("not supports_udfs")
 @pytest.mark.slow
 def test_udt_unary_ainv_abs_record(record_udt):
-    """``unary.ainv`` and ``unary.abs`` apply per field on a record UDT."""
     v = Vector(record_udt, size=3)
     v[0] = (1, 2.0)
     v[1] = (3, 4.0)
@@ -1637,7 +1634,6 @@ def test_udt_unary_ainv_abs_record(record_udt):
 @pytest.mark.skipif("not supports_udfs")
 @pytest.mark.slow
 def test_udt_matrix_apply_unary(record_udt):
-    """``Matrix.apply`` works on a record-UDT-valued matrix."""
     M = Matrix(record_udt, nrows=2, ncols=2)
     M[0, 0] = (1, 2.0)
     M[0, 1] = (3, 4.0)
@@ -1645,6 +1641,8 @@ def test_udt_matrix_apply_unary(record_udt):
     M[1, 1] = (7, 8.0)
     result = M.apply(unary.ainv).new()
     assert result[0, 0].new() == (-1, -2.0)
+    assert result[0, 1].new() == (-3, -4.0)
+    assert result[1, 0].new() == (-5, -6.0)
     assert result[1, 1].new() == (-7, -8.0)
 
 
@@ -1679,7 +1677,6 @@ def test_udt_builtin_binary_array(array_udt, op_name, expected):
 @pytest.mark.skipif("not supports_udfs")
 @pytest.mark.slow
 def test_udt_unary_ainv_abs_array(array_udt):
-    """``unary.ainv`` / ``unary.abs`` apply per element on an array UDT."""
     a, _b = _array_pair(array_udt)
     np.testing.assert_array_equal(a.apply(unary.ainv).new()[0].new().value, [-1.0, -2.0, -3.0])
     c = Vector(array_udt, size=2)
@@ -1716,7 +1713,7 @@ def test_udt_jit_typedef():
     arr_udt = dtypes.register_anonymous(arr_dtype, "Vec7")
     lib.GrB_Type_get_String(arr_udt._carg, buf, lib.GxB_JIT_C_DEFINITION)
     defn = ffi.string(buf).decode()
-    assert "double v [7]" in defn or "double v[7]" in defn
+    assert "double v [7]" in defn
     assert "Vec7" in defn
 
     # 2D array UDT
@@ -1927,7 +1924,6 @@ def test_udt_auto_semiring():
 @pytest.mark.skipif("not supports_udfs")
 @pytest.mark.slow
 def test_udt_single_field_record():
-    """A single-field record UDT works for binary and reduce paths."""
     single_dtype = np.dtype([("val", np.float64)], align=True)
     single_udt = dtypes.register_anonymous(single_dtype)
     v = Vector(single_udt, 2)
@@ -1938,6 +1934,7 @@ def test_udt_single_field_record():
     w[1] = (20.0,)
     result = binary.plus(v & w).new()
     assert result[0].new() == (13.0,)
+    assert result[1].new() == (27.0,)
     assert v.reduce(monoid.plus).new() == (10.0,)
 
 
@@ -1954,7 +1951,10 @@ def test_udt_bool_field_record():
     bw[0] = (True, 10)
     bw[1] = (True, 20)
     result = binary.plus(bv & bw).new()
-    assert result[0].new().value[1] == 11  # count field
+    # count field sums normally; flag is ``bool(a + b)``, so it's False only
+    # when both inputs are False.
+    assert result[0].new().value.tolist() == (True, 11)
+    assert result[1].new().value.tolist() == (True, 22)
 
 
 @pytest.mark.skipif("not supports_udfs")
@@ -1974,7 +1974,6 @@ def test_udt_op_compilation_is_lazy():
 @pytest.mark.skipif("not supports_udfs")
 @pytest.mark.slow
 def test_udt_large_array():
-    """A 100-element array UDT compiles and runs."""
     big_dtype = np.dtype((np.float64, (100,)))
     big_udt = dtypes.register_anonymous(big_dtype)
     a = Vector(big_udt, 2)
@@ -1984,13 +1983,13 @@ def test_udt_large_array():
     b[0] = [1.0] * 100
     b[1] = [1.0] * 100
     result = binary.plus(a & b).new()
-    np.testing.assert_array_equal(result[0].new().value[:3], [1.0, 2.0, 3.0])
+    np.testing.assert_array_equal(result[0].new().value, np.arange(1.0, 101.0))
+    np.testing.assert_array_equal(result[1].new().value, np.arange(101.0, 201.0))
 
 
 @pytest.mark.skipif("not supports_udfs")
 @pytest.mark.slow
 def test_udt_int_array():
-    """An integer array UDT applies binary ops element-by-element."""
     int_arr_dtype = np.dtype((np.int32, (4,)))
     int_arr_udt = dtypes.register_anonymous(int_arr_dtype)
     iv = Vector(int_arr_udt, 2)
@@ -2001,6 +2000,7 @@ def test_udt_int_array():
     iw[1] = [50, 60, 70, 80]
     result = binary.times(iv & iw).new()
     np.testing.assert_array_equal(result[0].new().value, [10, 40, 90, 160])
+    np.testing.assert_array_equal(result[1].new().value, [250, 360, 490, 640])
 
 
 @pytest.mark.skipif("not supports_udfs")
@@ -2185,6 +2185,7 @@ def test_udt_array_scalar_broadcast_plus_times(broadcast_array_udt):
     np.testing.assert_array_equal(res_lhs[0].new().value, [11.0, 12.0, 13.0])
     np.testing.assert_array_equal(res_lhs[1].new().value, [104.0, 105.0, 106.0])
     np.testing.assert_array_equal(res_rhs[0].new().value, [11.0, 12.0, 13.0])
+    np.testing.assert_array_equal(res_rhs[1].new().value, [104.0, 105.0, 106.0])
 
     res_times = binary.times(vec_arr & vec_s).new()
     np.testing.assert_array_equal(res_times[0].new().value, [10.0, 20.0, 30.0])
@@ -2221,26 +2222,26 @@ def test_udt_matrix_scalar_broadcast(broadcast_record_udt):
     assert result[1, 1].new() == (41.0, 42.0)
 
 
+# eq/ne broadcasting between a UDT and a scalar type.
+#
+# Before this fix, ``binary.eq(udt_vec & int_vec)`` silently reinterpreted
+# the int cell as a UDT struct (reading past the cell) and produced
+# byte-comparison nonsense that happened to look like plausible False/True.
+# Now the scalar broadcasts to every leaf, so ``eq`` is true only when all
+# leaves equal the scalar.
+
+
 @pytest.mark.skipif("not supports_udfs")
 @pytest.mark.slow
-def test_udt_eq_ne_scalar_broadcast():
-    """eq/ne broadcasting between a UDT and a scalar type.
-
-    Before this fix, ``binary.eq(udt_vec & int_vec)`` silently
-    reinterpreted the int cell as a UDT struct (reading past the cell)
-    and produced byte-comparison nonsense that happened to look like
-    plausible False/True. Now the scalar broadcasts to every leaf, so
-    ``eq`` is true only when all leaves equal the scalar.
-    """
-    # ---- Record UDT vs scalar ----
+def test_udt_eq_ne_scalar_broadcast_record():
     record = dtypes.register_anonymous(
         np.dtype([("u", np.float64), ("v", np.float64)], align=True),
         name="_EqBcastUV",
     )
     v_udt = Vector(record, size=3)
-    v_udt[0] = (10.0, 10.0)  # all equal to 10 -> eq True
-    v_udt[1] = (10.0, 20.0)  # partial match -> eq False
-    v_udt[2] = (1.0, 2.0)  # no match -> eq False
+    v_udt[0] = (10.0, 10.0)
+    v_udt[1] = (10.0, 20.0)  # partial match
+    v_udt[2] = (1.0, 2.0)  # no match
     v_int = Vector.from_coo([0, 1, 2], [10, 10, 10])
 
     eq_result = binary.eq(v_udt & v_int).new()
@@ -2255,8 +2256,18 @@ def test_udt_eq_ne_scalar_broadcast():
     eq_rev = binary.eq(v_int & v_udt).new()
     assert eq_rev.isequal(expected_eq)
 
-    # NaN propagation through the broadcast: a NaN leaf never equals
-    # anything, even another NaN.
+
+@pytest.mark.skipif("not supports_udfs")
+@pytest.mark.slow
+def test_udt_eq_ne_scalar_broadcast_nan_propagates():
+    """A NaN leaf never equals anything, even another NaN."""
+    # Distinct field names from the sibling record test: ``register_anonymous``
+    # keys on ``np.dtype``, so reusing ``("u", "v")`` would alias the cached
+    # DataType across tests (see CLAUDE.md).
+    record = dtypes.register_anonymous(
+        np.dtype([("nan_u", np.float64), ("nan_v", np.float64)], align=True),
+        name="_EqBcastUVNan",
+    )
     v_nan = Vector(record, size=3)
     v_nan[0] = (np.nan, 5.0)
     v_nan[1] = (5.0, 5.0)
@@ -2265,7 +2276,10 @@ def test_udt_eq_ne_scalar_broadcast():
     eq_nan = binary.eq(v_nan & v_five).new()
     assert eq_nan.isequal(Vector.from_coo([0, 1, 2], [False, True, False]))
 
-    # ---- Array UDT (1D and 2D) vs scalar ----
+
+@pytest.mark.skipif("not supports_udfs")
+@pytest.mark.slow
+def test_udt_eq_ne_scalar_broadcast_array_1d():
     arr1d = dtypes.register_anonymous(np.dtype((np.float64, (3,))), name="_EqBcastA3")
     v_a = Vector(arr1d, size=2)
     v_a[0] = [1.0, 1.0, 1.0]
@@ -2274,6 +2288,10 @@ def test_udt_eq_ne_scalar_broadcast():
     eq_a = binary.eq(v_a & v_one).new()
     assert eq_a.isequal(Vector.from_coo([0, 1], [True, False]))
 
+
+@pytest.mark.skipif("not supports_udfs")
+@pytest.mark.slow
+def test_udt_eq_ne_scalar_broadcast_array_2d():
     arr2d = dtypes.register_anonymous(np.dtype((np.float64, (2, 2))), name="_EqBcastA22")
     v_a22 = Vector(arr2d, size=2)
     v_a22[0] = [[3.0, 3.0], [3.0, 3.0]]
@@ -2282,7 +2300,10 @@ def test_udt_eq_ne_scalar_broadcast():
     eq_a22 = binary.eq(v_a22 & v_three).new()
     assert eq_a22.isequal(Vector.from_coo([0, 1], [True, False]))
 
-    # ---- Nested record vs scalar ----
+
+@pytest.mark.skipif("not supports_udfs")
+@pytest.mark.slow
+def test_udt_eq_ne_scalar_broadcast_nested_record():
     inner = np.dtype([("a", np.float64), ("b", np.float64)], align=True)
     nested = dtypes.register_anonymous(
         np.dtype([("outer", np.float64), ("inner", inner)], align=True),
@@ -2296,7 +2317,10 @@ def test_udt_eq_ne_scalar_broadcast():
     eq_n = binary.eq(v_n & v_5).new()
     assert eq_n.isequal(Vector.from_coo([0, 1, 2], [True, False, False]))
 
-    # ---- Record with array sub-field vs scalar ----
+
+@pytest.mark.skipif("not supports_udfs")
+@pytest.mark.slow
+def test_udt_eq_ne_scalar_broadcast_record_with_array_subfield():
     rec_arr = dtypes.register_anonymous(
         np.dtype([("a", np.float64), ("v", np.float64, (3,))], align=True),
         name="_EqBcastRecArr",
@@ -2428,15 +2452,20 @@ def test_udt_lazy_registration():
         assert add_op(v & v).new()[0].new() == (2, 4.0)
         assert v.apply(neg_op).new()[0].new() == (-1, -2.0)
     finally:
-        # Clean up the namespace so test_operator_types' enumeration of
-        # binary/unary/indexunary doesn't see these UDT-only ops.
+        # Remove these UDT-only ops from every namespace they leaked into,
+        # including the combined ``op`` (binary and unary register there too).
+        # ``test_dir`` enumerates module names, and test_op_namespace iterates
+        # ``op._delayed`` and would fail to resolve an op whose per-type entry
+        # is gone. Pop ``__dict__`` and ``_delayed`` directly to avoid
+        # re-triggering ``__getattr__``.
         for module, name in [
             (binary, "_lazy_udt_add"),
             (unary, "_lazy_udt_neg"),
             (indexunary, "_lazy_udt_iu"),
+            (op, "_lazy_udt_add"),
+            (op, "_lazy_udt_neg"),
         ]:
-            if hasattr(module, name):
-                delattr(module, name)
+            vars(module).pop(name, None)
             module._delayed.pop(name, None)
 
 
@@ -2628,6 +2657,46 @@ def test_is_idempotent():
         binary.min.is_idempotent
 
 
+def _isidem_factory(scale):  # pragma: no cover (called by Numba)
+    # Plain arithmetic so the binop compiles for every builtin type that
+    # ``BinaryOp._build`` samples, including complex (no ``>`` lowering).
+    def inner(x, y):
+        return (x + y) * scale
+
+    return inner
+
+
+def _isidem_pick_first(x, y):  # pragma: no cover (called by Numba)
+    # Returning ``x`` is trivially idempotent (``op(x, x) == x``) and
+    # compiles for every builtin type, including complex where ``max``
+    # has no Numba lowering.
+    return x
+
+
+@pytest.mark.skipif("not supports_udfs")
+def test_monoid_pickle_preserves_is_idempotent():
+    """Regression: anonymous ``Monoid`` and ``ParameterizedMonoid`` both
+    dropped ``is_idempotent`` from the pickle round-trip, silently turning
+    a known-idempotent op into a non-idempotent one. Both
+    ``Monoid.__reduce__`` and ``ParameterizedMonoid.__reduce__`` now carry
+    the flag explicitly so ``_deserialize`` can pass it to
+    ``register_anonymous`` / ``register_new``.
+    """
+    import pickle
+
+    # Plain Monoid (non-parameterized) over an anonymous BinaryOp.
+    bin_op = BinaryOp.register_anonymous(_isidem_pick_first, "isidem_pick_first")
+    mon = Monoid.register_anonymous(bin_op, 0, "isidem_monoid", is_idempotent=True)
+    assert mon.is_idempotent is True
+    assert pickle.loads(pickle.dumps(mon)).is_idempotent is True
+
+    # ParameterizedMonoid wrapping a ParameterizedBinaryOp.
+    pbin = BinaryOp.register_anonymous(_isidem_factory, parameterized=True)
+    pmon = Monoid.register_anonymous(pbin, 0, "isidem_param_monoid", is_idempotent=True)
+    assert pmon.is_idempotent is True
+    assert pickle.loads(pickle.dumps(pmon)).is_idempotent is True
+
+
 def _parameterized_is_udt_factory(scale):  # pragma: no cover (called by Numba inside the op)
     def inner(x, y):
         return x * scale + y * scale
@@ -2696,11 +2765,18 @@ def test_compile_codegen_helper():
     assert co_filename.startswith("<gb-udt-helper-test plus> #")
     assert "x + y" in "".join(linecache.cache[co_filename][2])
 
-    # A bad source surfaces as RuntimeError with the offending source attached.
+    # A bad source surfaces as RuntimeError with the offending source attached
+    # and the underlying SyntaxError as ``__cause__``.
     bad_src = "def _op(x, y):\n    return (x + y\n"  # missing close paren
-    with pytest.raises(RuntimeError, match=r"(?s)not valid Python.*x \+ y"):
+    with pytest.raises(RuntimeError) as exc_info:
         _compile_codegen(
             bad_src,
             func_name="_op",
             source_label="<gb-udt-helper-test typo>",
         )
+    msg = str(exc_info.value)
+    assert "<gb-udt-helper-test typo>" in msg
+    assert "not valid Python" in msg
+    assert "Source:" in msg
+    assert bad_src in msg
+    assert isinstance(exc_info.value.__cause__, SyntaxError)

--- a/graphblas/tests/test_pickle.py
+++ b/graphblas/tests/test_pickle.py
@@ -433,6 +433,58 @@ def test_udt_pickle_crossprocess():
         gb.core.dtypes._registry.pop(udt_name, None)
 
 
+def _crossproc_parameterized_is_udt_factory(scale):  # pragma: no cover (called by Numba)
+    def inner(x, y):
+        return x * scale + y * scale
+
+    return inner
+
+
+def _op_compile_parameterized_is_udt(d):
+    op = d["op"]
+    # ``op._is_udt`` must survive the spawn so the right compile path runs in the child.
+    return bool(op._is_udt)
+
+
+_CROSSPROC_OPS["compile_parameterized_is_udt"] = _op_compile_parameterized_is_udt
+
+
+@pytest.mark.skipif("not supports_udfs")
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "module_name",
+    ["unary", "binary", "indexunary", "select", "indexbinary"],
+)
+def test_parameterized_is_udt_pickle_crossprocess(module_name):
+    """``is_udt`` survives a spawn -> unpickle -> re-register chain.
+
+    Same-process pickle is covered by ``test_parameterized_is_udt_pickle_roundtrip``
+    in ``test_op.py``; this exercises the cross-process path that wave-5
+    fixed (parameterized ``__reduce__`` used to drop ``is_udt`` and the
+    child silently took the non-UDT compile path).
+    """
+    module = getattr(gb, module_name)
+    op_name = f"_cpu_param_is_udt_{module_name}"
+    if hasattr(module, op_name):
+        delattr(module, op_name)
+    module.register_new(
+        op_name, _crossproc_parameterized_is_udt_factory, parameterized=True, is_udt=True
+    )
+    try:
+        op = getattr(module, op_name)
+        assert op._is_udt is True
+        payload = pickle.dumps({"op": op})
+        (got,) = _run_crossproc("compile_parameterized_is_udt", payload)
+        assert got is True
+    finally:
+        delattr(module, op_name)
+        # binary and unary ops also register into the combined ``op`` namespace,
+        # which ``delattr(module, ...)`` doesn't touch; clean it so
+        # test_op_namespace doesn't see an op with no per-type home.
+        vars(gb.op).pop(op_name, None)
+        gb.op._delayed.pop(op_name, None)
+
+
 @pytest.mark.skipif("not supports_udfs")
 @pytest.mark.slow
 def test_bound_ibo_pickle_crossprocess():

--- a/graphblas/tests/test_scalar.py
+++ b/graphblas/tests/test_scalar.py
@@ -198,6 +198,21 @@ def test_isclose():
     assert Scalar.from_value(None, dtype="FP64").isclose(Scalar.from_value(None, dtype="FP32"))
 
 
+def test_isclose_udt_raises():
+    """Reject ``isclose`` on UDTs with a clear message that points to isequal."""
+    arr_udt = dtypes.register_anonymous(np.dtype((np.int64, (3,))), "_IscloseUdt3")
+    s = gb.Scalar(arr_udt)
+    s.value = np.array([1, 2, 3], dtype=np.int64)
+    other = gb.Scalar(arr_udt)
+    other.value = np.array([1, 2, 3], dtype=np.int64)
+    # A raw value and a typed UDT Scalar both get the same clear message.
+    for arg in (np.array([1, 2, 3], dtype=np.int64), other):
+        with pytest.raises(TypeError, match="isclose is not defined for user-defined types"):
+            s.isclose(arg)
+    # isequal (the suggested alternative) does work for UDTs.
+    assert s.isequal(other)
+
+
 def test_nvals(s):
     assert s.nvals == 1
     s.clear()

--- a/graphblas/tests/test_ssjit.py
+++ b/graphblas/tests/test_ssjit.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import sysconfig
 
@@ -39,6 +40,14 @@ if backend != "suitesparse":
 # can call it themselves. Tests use it through the public surface.
 _fix_jit_config = gb.ss.fix_jit_config if not _IS_SSGB7 else (lambda: None)
 
+# Capture the post-import JIT state before the autouse ``_setup_jit`` fixture
+# runs. ``_auto_fix_jit_at_import`` probes once; ``jit_c_control`` is ``'on'``
+# iff the env can actually JIT-compile. Tests that assert on the import-time
+# state read this constant; the fixture may transiently mutate the live config.
+_JIT_WORKS_AT_IMPORT = (
+    not _IS_SSGB7 and backend == "suitesparse" and gb.ss.config["jit_c_control"] == "on"
+)
+
 
 @pytest.fixture(scope="module", autouse=True)
 def _setup_jit():
@@ -47,7 +56,9 @@ def _setup_jit():
     Strategy:
     1. _fix_jit_config(): fix conda-baked compiler paths and probe.
        - Returns True: JIT works, proceed.
-       - Returns False: probe failed, JIT is broken, turn off.
+       - Returns False: probe failed. SuiteSparse will have left
+         ``jit_c_control = 'load'`` (compile disabled, cache loading
+         still allowed); we leave that state untouched.
        - Returns None: no conda env, try sysconfig instead.
     2. Sysconfig fallback: for non-conda installs (pure pip).
     """
@@ -59,15 +70,12 @@ def _setup_jit():
     prev = gb.ss.config["jit_c_control"]
 
     result = _fix_jit_config()
-    if result is True:
-        pass  # Conda JIT configured and verified
-    elif result is False:
-        # Probe failed; JIT doesn't work with this psg build.
-        # Don't try sysconfig; if the conda compiler can't compile
-        # GraphBLAS JIT kernels, Python's sysconfig compiler won't either.
-        gb.ss.config["jit_c_control"] = "off"
-    else:
-        # No conda env (result is None). Try sysconfig for non-conda installs.
+    # ``True``: conda JIT configured and verified. ``False``: probe failed
+    # (``_probe_jit`` leaves ``jit_c_control`` at ``'load'``; don't try
+    # sysconfig, since if the conda compiler can't build GraphBLAS JIT
+    # kernels, Python's sysconfig compiler won't either). Both done.
+    if result is None:
+        # No conda env. Try sysconfig for non-conda installs.
         cc = sysconfig.get_config_var("CC")
         cflags = sysconfig.get_config_var("CFLAGS")
         include = sysconfig.get_path("include")
@@ -78,9 +86,24 @@ def _setup_jit():
             gb.ss.config["jit_c_compiler_flags"] = f"{cflags} -I{include}"
             if libs:
                 gb.ss.config["jit_c_libraries"] = libs
-        else:
-            gb.ss.config["jit_c_control"] = "off"
 
+    try:
+        yield
+    finally:
+        gb.ss.config["jit_c_control"] = prev
+
+
+def _require_jit_on():
+    """Skip the test if the SuiteSparse JIT can't compile in this environment."""
+    if gb.ss.config["jit_c_control"] != "on":
+        pytest.skip("JIT compilation not available (probe failed or compiler missing)")
+
+
+@contextlib.contextmanager
+def _jit_mode(mode):
+    """Temporarily set ``jit_c_control`` to ``mode``; restore on exit."""
+    prev = gb.ss.config["jit_c_control"]
+    gb.ss.config["jit_c_control"] = mode
     try:
         yield
     finally:
@@ -89,15 +112,29 @@ def _setup_jit():
 
 @pytest.mark.skipif("_IS_SSGB7")
 def test_auto_fix_jit_at_import_left_compiler_usable():
-    """After ``import graphblas.ss``, a usable compiler implies ``jit_c_control == 'on'``."""
+    """After ``import graphblas.ss``, a probe-confirmed compiler implies
+    ``jit_c_control == 'on'``.
+    """
     if not gb.ss.jit_compiler_is_usable():
         pytest.skip("sandboxed env without a usable compiler; auto-fix had nothing to repair")
+    if not _JIT_WORKS_AT_IMPORT:
+        # Compiler file exists but the import-time probe failed (e.g., the
+        # baked-in flags target a different arch than the host). After a
+        # compile failure SuiteSparse drops ``jit_c_control`` to a
+        # non-compiling mode so downstream ops punt to generic cleanly; the
+        # probe absorbs that first failure. Which mode it lands in (``'load'``
+        # or ``'run'``) varies by SuiteSparse version.
+        assert gb.ss.config["jit_c_control"] in {"load", "run"}
+        pytest.skip("compiler present but JIT probe failed in this env")
+    assert _JIT_WORKS_AT_IMPORT
     assert gb.ss.config["jit_c_control"] == "on"
 
 
 @pytest.mark.skipif("_IS_SSGB7")
 def test_public_fix_jit_config_repairs_a_broken_compiler():
     """``gb.ss.fix_jit_config()`` repairs a clobbered compiler path and returns ``True``."""
+    if not _JIT_WORKS_AT_IMPORT:
+        pytest.skip("env JIT doesn't actually compile; nothing to repair to")
     prev = {
         "control": gb.ss.config["jit_c_control"],
         "cc": gb.ss.config["jit_c_compiler_name"],
@@ -157,8 +194,7 @@ def test_jit_udt():
                 "myquaternion", "typedef struct { float x [4][4] ; int color ; } myquaternion ;"
             )
         return
-    if gb.ss.config["jit_c_control"] == "off":
-        pytest.skip("JIT not available (no C compiler configured)")
+    _require_jit_on()
     with burble():
         dtype = dtypes.ss.register_new(
             "myquaternion", "typedef struct { float x [4][4] ; int color ; } myquaternion ;"
@@ -205,15 +241,14 @@ def test_jit_unary(v):
         with pytest.raises(RuntimeError, match="JIT was added"):
             unary.ss.register_new("square", cdef, "FP32", "FP32")
         return
-    if gb.ss.config["jit_c_control"] == "off":
-        pytest.skip("JIT not available (no C compiler configured)")
+    _require_jit_on()
     with burble():
         square = unary.ss.register_new("square", cdef, "FP32", "FP32")
     assert not hasattr(unary, "square")
     assert unary.ss.square is square
     assert square.name == "ss.square"
     assert square.types == {dtypes.FP32: dtypes.FP32}
-    # The JIT is unforgiving and does not coerce--use the correct types!
+    # JIT ops don't coerce: wrong dtype raises KeyError, not a silent cast.
     with pytest.raises(KeyError, match="square does not work with INT64"):
         v << square(v)
     v = v.dup("FP32")
@@ -244,8 +279,7 @@ def test_jit_binary(v):
         with pytest.raises(RuntimeError, match="JIT was added"):
             binary.ss.register_new("absdiff", cdef, "FP64", "FP64", "FP64")
         return
-    if gb.ss.config["jit_c_control"] == "off":
-        pytest.skip("JIT not available (no C compiler configured)")
+    _require_jit_on()
     with burble():
         absdiff = binary.ss.register_new(
             "absdiff",
@@ -260,7 +294,7 @@ def test_jit_binary(v):
     assert absdiff.types == {(dtypes.FP64, dtypes.FP64): dtypes.FP64}  # different than normal
     assert "FP64" in absdiff
     assert absdiff["FP64"].return_type == dtypes.FP64
-    # The JIT is unforgiving and does not coerce--use the correct types!
+    # JIT ops don't coerce: wrong dtype raises KeyError, not a silent cast.
     with pytest.raises(KeyError, match="absdiff does not work with .INT64, INT64. types"):
         v << absdiff(v & v)
     w = (v - 1).new("FP64")
@@ -313,8 +347,7 @@ def test_jit_indexunary(v):
         with pytest.raises(RuntimeError, match="JIT was added"):
             indexunary.ss.register_new("diffy", cdef, "FP64", "FP64", "FP64")
         return
-    if gb.ss.config["jit_c_control"] == "off":
-        pytest.skip("JIT not available (no C compiler configured)")
+    _require_jit_on()
     with burble():
         diffy = indexunary.ss.register_new("diffy", cdef, "FP64", "FP64", "FP64")
     assert not hasattr(indexunary, "diffy")
@@ -325,7 +358,7 @@ def test_jit_indexunary(v):
     assert diffy.types == {(dtypes.FP64, dtypes.FP64): dtypes.FP64}
     assert "FP64" in diffy
     assert diffy["FP64"].return_type == dtypes.FP64
-    # The JIT is unforgiving and does not coerce--use the correct types!
+    # JIT ops don't coerce: wrong dtype raises KeyError, not a silent cast.
     with pytest.raises(KeyError, match="diffy does not work with .INT64, INT64. types"):
         v << diffy(v, 1)
     v = v.dup("FP64")
@@ -376,8 +409,7 @@ def test_jit_indexbinary(v):
         "double *y, GrB_Index iy, GrB_Index jy, double *theta) "
         "{ (*z) = (*x) + (*y) + (*theta) ; }"
     )
-    if gb.ss.config["jit_c_control"] == "off":
-        pytest.skip("JIT not available (no C compiler configured)")
+    _require_jit_on()
     with burble():
         add_theta = indexbinary.ss.register_new("add_theta", cdef, "FP64", "FP64", "FP64", "FP64")
     assert not hasattr(indexbinary, "add_theta")
@@ -435,7 +467,8 @@ def test_jit_indexbinary(v):
 @pytest.mark.slow
 def test_jit_select(v):
     cdef = (
-        # Why does this one insist on `const` for `x` argument?
+        # SelectOps don't write to their input array, so SuiteSparse requires
+        # the x argument to be ``const``.
         "void woot (bool *z, const int32_t *x, GrB_Index i, GrB_Index j, int32_t *y) "
         "{ (*z) = ((*x) + i + j == (*y)) ; }"
     )
@@ -443,8 +476,7 @@ def test_jit_select(v):
         with pytest.raises(RuntimeError, match="JIT was added"):
             select.ss.register_new("woot", cdef, "INT32", "INT32")
         return
-    if gb.ss.config["jit_c_control"] == "off":
-        pytest.skip("JIT not available (no C compiler configured)")
+    _require_jit_on()
     with burble():
         woot = select.ss.register_new("woot", cdef, "INT32", "INT32")
     assert not hasattr(select, "woot")
@@ -455,7 +487,7 @@ def test_jit_select(v):
     assert woot.types == {(dtypes.INT32, dtypes.INT32): dtypes.BOOL}
     assert "INT32" in woot
     assert woot["INT32"].return_type == dtypes.BOOL
-    # The JIT is unforgiving and does not coerce--use the correct types!
+    # JIT ops don't coerce: wrong dtype raises KeyError, not a silent cast.
     with pytest.raises(KeyError, match="woot does not work with .INT64, INT64. types"):
         v << woot(v, 1)
     v = v.dup("INT32")
@@ -575,35 +607,6 @@ def test_udt_jit_c_source_introspection():
 
 @pytest.mark.skipif("not supports_udfs")
 @pytest.mark.skipif("_IS_SSGB7")
-def test_anonymous_udt_gets_jit_c_name():
-    """Anonymous UDTs (registered via ``register_anonymous``) must also get
-    ``GxB_JIT_C_NAME`` set on their auto-lifted ops, so SuiteSparse JIT can
-    expand kernels for them.
-
-    Belt-and-suspenders coverage: the dtype's own JIT C name should also be set.
-    Uses field names unique to this test to avoid colliding with other test UDTs.
-    """
-    record_dtype = np.dtype([("anonj_x", np.int64), ("anonj_y", np.int64)], align=True)
-    udt = dtypes.register_anonymous(record_dtype, "_AnonJitUdt")
-
-    # The anonymous UDT itself has a JIT-resolvable C name and typedef.
-    assert udt.jit_c_name == "_AnonJitUdt"
-    assert udt.jit_c_definition is not None
-
-    # Auto-lift an op on the anonymous UDT. Both the C name and the C
-    # source must be set; these are what SuiteSparse needs to JIT-compile.
-    op = binary.plus[udt]
-    assert op.jit_c_name == "plus__AnonJitUdt"
-    assert op.jit_c_source is not None
-
-    # Same for unary
-    op_unary = unary.ainv[udt]
-    assert op_unary.jit_c_name == "ainv__AnonJitUdt"
-    assert op_unary.jit_c_source is not None
-
-
-@pytest.mark.skipif("not supports_udfs")
-@pytest.mark.skipif("_IS_SSGB7")
 def test_op_jit_signature_uses_pinned_type_name():
     """After a UDT is renamed, auto-lifted ops must still reference the
     pinned (first-registration) C name in their signature. SS's
@@ -638,8 +641,7 @@ def test_jit_compiles_auto_udt_ops():
     """
     if _IS_SSGB7:
         pytest.skip("JIT requires SuiteSparse:GraphBLAS >= 8")
-    if gb.ss.config["jit_c_control"] == "off":
-        pytest.skip("JIT not available (no C compiler configured)")
+    _require_jit_on()
 
     record_dtype = np.dtype([("a", np.int64), ("b", np.float64)], align=True)
     udt = dtypes.register_anonymous(record_dtype, "_JitAutoUdt")
@@ -650,21 +652,17 @@ def test_jit_compiles_auto_udt_ops():
     v[2] = (5, 6.0)
     w = v.dup()
 
-    # Force JIT on and probe.  If our typedef + JIT_C_NAME wiring is correct,
+    # Force JIT on and probe. If our typedef + JIT_C_NAME wiring is correct,
     # SuiteSparse should compile and load the kernel without errors.
-    prev_control = gb.ss.config["jit_c_control"]
-    gb.ss.config["jit_c_control"] = "on"
-    try:
+    with _jit_mode("on"):
         with burble():
             result = binary.plus(v & w).new()
         assert result[0].new() == (2, 4.0)
         assert result[2].new() == (10, 12.0)
-        # JIT must not have been disabled by a compilation failure.
+        # JIT must remain in compile-on mode; a failed compile flips it to 'load'.
         assert (
-            gb.ss.config["jit_c_control"] != "off"
-        ), "JIT was disabled after compiling a built-in UDT op (typedef/name wiring is broken)"
-    finally:
-        gb.ss.config["jit_c_control"] = prev_control
+            gb.ss.config["jit_c_control"] == "on"
+        ), "JIT compilation got disabled (flipped from 'on' to 'load') after a built-in UDT op"
 
 
 @pytest.mark.skipif("not supports_udfs")
@@ -681,8 +679,7 @@ def test_floordiv_udt_jit_matches_python_semantics():
     """
     if _IS_SSGB7:
         pytest.skip("JIT requires SuiteSparse:GraphBLAS >= 8")
-    if gb.ss.config["jit_c_control"] == "off":
-        pytest.skip("JIT not available (no C compiler configured)")
+    _require_jit_on()
 
     N = 50
 
@@ -745,8 +742,7 @@ def test_min_max_udt_jit_propagates_nan():
     """
     if _IS_SSGB7:
         pytest.skip("JIT requires SuiteSparse:GraphBLAS >= 8")
-    if gb.ss.config["jit_c_control"] == "off":
-        pytest.skip("JIT not available (no C compiler configured)")
+    _require_jit_on()
 
     # Field names unique to this test; see floordiv test for the cache rationale.
     udt = dtypes.register_anonymous(
@@ -786,8 +782,7 @@ def test_abs_udt_jit_matches_python_negative_zero():
     """
     if _IS_SSGB7:
         pytest.skip("JIT requires SuiteSparse:GraphBLAS >= 8")
-    if gb.ss.config["jit_c_control"] == "off":
-        pytest.skip("JIT not available (no C compiler configured)")
+    _require_jit_on()
 
     import struct
 
@@ -906,8 +901,7 @@ def test_udt_op_jit_cfunc_parity(udt_kind):
     """
     if _IS_SSGB7:
         pytest.skip("JIT requires SuiteSparse:GraphBLAS >= 8")
-    if gb.ss.config["jit_c_control"] == "off":
-        pytest.skip("JIT not available (no C compiler configured)")
+    _require_jit_on()
     if numba is None:
         pytest.skip("numba required for the cfunc baseline")
 
@@ -924,19 +918,14 @@ def test_udt_op_jit_cfunc_parity(udt_kind):
     binary_ops = ["plus", "minus", "times", "truediv", "floordiv", "min", "max"]
     unary_ops = ["ainv", "abs"]
 
-    prev = gb.ss.config["jit_c_control"]
-    try:
-        # JIT path
-        gb.ss.config["jit_c_control"] = "on"
+    with _jit_mode("on"):
         jit_binary = {op: v.ewise_mult(u, getattr(binary, op)).new() for op in binary_ops}
         jit_unary = {op: getattr(unary, op)(v).new() for op in unary_ops}
-        # cfunc path: turn JIT off so SS uses the registered function pointer
-        # instead of compiling a new kernel.
-        gb.ss.config["jit_c_control"] = "off"
+    # cfunc path: JIT off so SS uses the registered function pointer instead of
+    # compiling a new kernel.
+    with _jit_mode("off"):
         cf_binary = {op: v.ewise_mult(u, getattr(binary, op)).new() for op in binary_ops}
         cf_unary = {op: getattr(unary, op)(v).new() for op in unary_ops}
-    finally:
-        gb.ss.config["jit_c_control"] = prev
 
     def values_equal(j, c):
         # Compare raw bytes via ``to_dense`` rather than ``isequal``. With the
@@ -971,8 +960,7 @@ def test_anonymous_udt_with_no_name_still_jits():
     """
     if _IS_SSGB7:
         pytest.skip("JIT requires SuiteSparse:GraphBLAS >= 8")
-    if gb.ss.config["jit_c_control"] == "off":
-        pytest.skip("JIT not available (no C compiler configured)")
+    _require_jit_on()
 
     spec = np.dtype([("anon_a", np.float64), ("anon_b", np.int64)], align=True)
     udt = dtypes.register_anonymous(spec)  # no name=
@@ -989,6 +977,17 @@ def test_anonymous_udt_with_no_name_still_jits():
     assert plus_op.jit_c_source is not None
     assert plus_op.jit_c_name.startswith("plus__gbudt_")
 
+    # Run the kernel to confirm the JIT path produces correct results.
+    v = gb.Vector(udt, 2)
+    v[0] = (1.0, 10)
+    v[1] = (2.0, 20)
+    w = gb.Vector(udt, 2)
+    w[0] = (3.0, 30)
+    w[1] = (4.0, 40)
+    result = v.ewise_mult(w, binary.plus).new()
+    assert result[0].new().value.tolist() == (4.0, 40)
+    assert result[1].new().value.tolist() == (6.0, 60)
+
 
 @pytest.mark.slow
 @pytest.mark.skipif("not supports_udfs")
@@ -1004,8 +1003,7 @@ def test_complex_field_udt_jits_arithmetic():
     """
     if _IS_SSGB7:
         pytest.skip("JIT requires SuiteSparse:GraphBLAS >= 8")
-    if gb.ss.config["jit_c_control"] == "off":
-        pytest.skip("JIT not available (no C compiler configured)")
+    _require_jit_on()
 
     spec = np.dtype([("cval", np.complex128), ("scale", np.float64)])
     udt = dtypes.register_anonymous(spec, "_JitCplx1")
@@ -1023,24 +1021,20 @@ def test_complex_field_udt_jits_arithmetic():
     # division and Numba's complex division differ in their last-bit
     # rounding / overflow handling, so they're equivalent within ulps but
     # not bit-identical.
-    prev = gb.ss.config["jit_c_control"]
-    try:
-        for op_name in ("plus", "minus", "times"):
-            op = getattr(binary, op_name)
-            gb.ss.config["jit_c_control"] = "on"
+    for op_name in ("plus", "minus", "times"):
+        op = getattr(binary, op_name)
+        with _jit_mode("on"):
             wj = v.ewise_mult(u, op).new()
-            gb.ss.config["jit_c_control"] = "off"
+        with _jit_mode("off"):
             wc = v.ewise_mult(u, op).new()
-            assert wj.isequal(wc, check_dtype=True), f"binary.{op_name} on complex UDT diverged"
-        for op_name in ("abs", "ainv"):
-            op = getattr(unary, op_name)
-            gb.ss.config["jit_c_control"] = "on"
+        assert wj.isequal(wc, check_dtype=True), f"binary.{op_name} on complex UDT diverged"
+    for op_name in ("abs", "ainv"):
+        op = getattr(unary, op_name)
+        with _jit_mode("on"):
             wj = op(v).new()
-            gb.ss.config["jit_c_control"] = "off"
+        with _jit_mode("off"):
             wc = op(v).new()
-            assert wj.isequal(wc, check_dtype=True), f"unary.{op_name} on complex UDT diverged"
-    finally:
-        gb.ss.config["jit_c_control"] = prev
+        assert wj.isequal(wc, check_dtype=True), f"unary.{op_name} on complex UDT diverged"
 
     # abs source must use cabs (not the ternary, which doesn't compile on _Complex).
     assert "cabs(" in unary.abs[udt].jit_c_source
@@ -1079,6 +1073,7 @@ def test_packed_record_layout_skips_jit():
     assert w[0].new() == (2, 3.0)
 
 
+@pytest.mark.skipif("not supports_udfs")
 def test_packed_nested_record_layout_skips_jit():
     """Packed-inside-packed must skip the JIT path too.
 
@@ -1120,8 +1115,7 @@ def test_nested_record_udt_jits():
     """
     if _IS_SSGB7:
         pytest.skip("JIT requires SuiteSparse:GraphBLAS >= 8")
-    if gb.ss.config["jit_c_control"] == "off":
-        pytest.skip("JIT not available (no C compiler configured)")
+    _require_jit_on()
 
     # ``align=True`` is required for mixed-width fields so numpy's offsets
     # match what a C compiler would produce. Without it, the JIT kernel
@@ -1155,24 +1149,20 @@ def test_nested_record_udt_jits():
         v[i] = (i, (1.0 + i, 2.0 + i))
         u[i] = (1, (0.5, -0.5))
 
-    prev = gb.ss.config["jit_c_control"]
-    try:
-        for op_name in ("plus", "minus", "times"):
-            op = getattr(binary, op_name)
-            gb.ss.config["jit_c_control"] = "on"
+    for op_name in ("plus", "minus", "times"):
+        op = getattr(binary, op_name)
+        with _jit_mode("on"):
             wj = v.ewise_mult(u, op).new()
-            gb.ss.config["jit_c_control"] = "off"
+        with _jit_mode("off"):
             wc = v.ewise_mult(u, op).new()
-            assert wj.isequal(wc, check_dtype=True), f"binary.{op_name} on nested UDT diverged"
-        for op_name in ("abs", "ainv"):
-            op = getattr(unary, op_name)
-            gb.ss.config["jit_c_control"] = "on"
+        assert wj.isequal(wc, check_dtype=True), f"binary.{op_name} on nested UDT diverged"
+    for op_name in ("abs", "ainv"):
+        op = getattr(unary, op_name)
+        with _jit_mode("on"):
             wj = op(v).new()
-            gb.ss.config["jit_c_control"] = "off"
+        with _jit_mode("off"):
             wc = op(v).new()
-            assert wj.isequal(wc, check_dtype=True), f"unary.{op_name} on nested UDT diverged"
-    finally:
-        gb.ss.config["jit_c_control"] = prev
+        assert wj.isequal(wc, check_dtype=True), f"unary.{op_name} on nested UDT diverged"
 
 
 @pytest.mark.slow
@@ -1234,87 +1224,97 @@ def test_nested_record_monoid_semiring_agg():
     assert (c11["agg_id"], c11["agg_pt"]["agg_x"], c11["agg_pt"]["agg_y"]) == (220, 1.0, 2.0)
 
 
+# Per-shape fill functions for the eq/ne JIT-vs-cfunc parity test below.
+# Each returns ``(v1_record, v2_record)`` for index ``i``. Variants that put
+# a NaN at index 0 also exercise IEEE comparison semantics (eq(NaN,NaN) is
+# False), pinned by the ``nan_at_zero`` flag in ``_EQ_NE_VARIANTS``.
+
+
+def _eq_ne_fill_record_float(i):
+    nan = float("nan")
+    if i == 0:
+        return (nan, 1.0), (nan, 1.0)
+    return (1.0 + i, 2.0), (1.0 + i, 2.0 if i % 2 == 0 else 3.0)
+
+
+def _eq_ne_fill_record_int(i):
+    return (i, 2 * i), (i, 2 * i if i % 3 == 0 else 2 * i + 1)
+
+
+def _eq_ne_fill_record_nested(i):
+    return (i, (1.0, 2.0)), (i, (1.0, 2.0) if i % 3 != 0 else (1.5, 2.0))
+
+
+def _eq_ne_fill_record_complex(i):
+    return (
+        (complex(1.0 + i, 2.0), 3.0),
+        (complex(1.0 + i, 2.0 if i % 2 == 0 else 3.0), 3.0),
+    )
+
+
+def _eq_ne_fill_array_f64(i):
+    return (
+        np.array([1.0 + i, 2.0, 3.0]),
+        np.array([1.0 + i, 2.0 if i % 2 == 0 else -2.0, 3.0]),
+    )
+
+
+_EQ_NE_VARIANTS = {
+    "record_float": (
+        np.dtype([("eq_f_a", np.float64), ("eq_f_b", np.float64)], align=True),
+        "_EqJitF",
+        _eq_ne_fill_record_float,
+        True,
+    ),
+    "record_int": (
+        np.dtype([("eq_i_a", np.int64), ("eq_i_b", np.int32)], align=True),
+        "_EqJitI",
+        _eq_ne_fill_record_int,
+        False,
+    ),
+    "record_nested": (
+        np.dtype(
+            [("eq_n_id", np.int32), ("eq_n_pt", [("nx", np.float64), ("ny", np.float64)])],
+            align=True,
+        ),
+        "_EqJitN",
+        _eq_ne_fill_record_nested,
+        False,
+    ),
+    "record_complex": (
+        np.dtype([("eq_c_z", np.complex128), ("eq_c_s", np.float64)]),
+        "_EqJitC",
+        _eq_ne_fill_record_complex,
+        False,
+    ),
+    "array_f64": (
+        np.dtype((np.float64, (3,))),
+        "_EqJitArr",
+        _eq_ne_fill_array_f64,
+        False,
+    ),
+}
+
+
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "shape",
-    [
-        "record_float",
-        "record_int",
-        "record_nested",
-        "record_complex",
-        "array_f64",
-    ],
-)
+@pytest.mark.parametrize("shape", list(_EQ_NE_VARIANTS))
 def test_eq_ne_udt_jit_matches_cfunc(shape):
     """``binary.eq[udt]`` / ``binary.ne[udt]`` JIT-compile a leaf-wise
     comparison kernel and produce the same result as the cfunc fallback.
 
     Verifies the JIT kernel for several shapes (flat record, nested
     record, complex, array UDT), and that NaN propagation matches IEEE
-    (``eq(NaN, NaN) == False``).
+    (``eq(NaN, NaN) == False``) on variants flagged ``nan_at_zero``.
     """
     if _IS_SSGB7:
         pytest.skip("JIT requires SuiteSparse:GraphBLAS >= 8")
-    if gb.ss.config["jit_c_control"] == "off":
-        pytest.skip("JIT not available (no C compiler configured)")
+    _require_jit_on()
     if numba is None:
         pytest.skip("numba required for the cfunc baseline")
 
+    np_dtype, type_name, fill, nan_at_zero = _EQ_NE_VARIANTS[shape]
+    udt = dtypes.register_anonymous(np_dtype, type_name)
     N = 64
-    if shape == "record_float":
-        udt = dtypes.register_anonymous(
-            np.dtype([("eq_f_a", np.float64), ("eq_f_b", np.float64)], align=True),
-            "_EqJitF",
-        )
-
-        def fill(i):
-            nan = float("nan")
-            if i == 0:
-                return (nan, 1.0), (nan, 1.0)  # NaN on both sides -> ne
-            return (1.0 + i, 2.0), (1.0 + i, 2.0 if i % 2 == 0 else 3.0)
-
-    elif shape == "record_int":
-        udt = dtypes.register_anonymous(
-            np.dtype([("eq_i_a", np.int64), ("eq_i_b", np.int32)], align=True),
-            "_EqJitI",
-        )
-
-        def fill(i):
-            return (i, 2 * i), (i, 2 * i if i % 3 == 0 else 2 * i + 1)
-
-    elif shape == "record_nested":
-        udt = dtypes.register_anonymous(
-            np.dtype(
-                [("eq_n_id", np.int32), ("eq_n_pt", [("nx", np.float64), ("ny", np.float64)])],
-                align=True,
-            ),
-            "_EqJitN",
-        )
-
-        def fill(i):
-            return (i, (1.0, 2.0)), (i, (1.0, 2.0) if i % 3 != 0 else (1.5, 2.0))
-
-    elif shape == "record_complex":
-        udt = dtypes.register_anonymous(
-            np.dtype([("eq_c_z", np.complex128), ("eq_c_s", np.float64)]),
-            "_EqJitC",
-        )
-
-        def fill(i):
-            return (complex(1.0 + i, 2.0), 3.0), (
-                complex(1.0 + i, 2.0 if i % 2 == 0 else 3.0),
-                3.0,
-            )
-
-    else:  # array_f64
-        udt = dtypes.register_anonymous(np.dtype((np.float64, (3,))), "_EqJitArr")
-
-        def fill(i):
-            return (
-                np.array([1.0 + i, 2.0, 3.0]),
-                np.array([1.0 + i, 2.0 if i % 2 == 0 else -2.0, 3.0]),
-            )
-
     v1 = gb.Vector(udt, N)
     v2 = gb.Vector(udt, N)
     for i in range(N):
@@ -1326,18 +1326,14 @@ def test_eq_ne_udt_jit_matches_cfunc(shape):
     assert binary.eq[udt].jit_c_source is not None
     assert binary.ne[udt].jit_c_source is not None
 
-    prev = gb.ss.config["jit_c_control"]
-    try:
-        gb.ss.config["jit_c_control"] = "on"
+    with _jit_mode("on"):
         eq_jit = v1.ewise_mult(v2, binary.eq).new()
         ne_jit = v1.ewise_mult(v2, binary.ne).new()
-        gb.ss.config["jit_c_control"] = "off"
+    with _jit_mode("off"):
         eq_cf = v1.ewise_mult(v2, binary.eq).new()
         ne_cf = v1.ewise_mult(v2, binary.ne).new()
-    finally:
-        gb.ss.config["jit_c_control"] = prev
 
-    # Byte-equal across paths (the result is BOOL, so this is just exact).
+    # Byte-equal across paths (the result is BOOL, so this is exact).
     assert (
         eq_jit.to_dense().tobytes() == eq_cf.to_dense().tobytes()
     ), f"eq on {shape}: JIT and cfunc disagree"
@@ -1345,10 +1341,8 @@ def test_eq_ne_udt_jit_matches_cfunc(shape):
         ne_jit.to_dense().tobytes() == ne_cf.to_dense().tobytes()
     ), f"ne on {shape}: JIT and cfunc disagree"
 
-    # IEEE NaN sanity: when both records carry NaN, eq[0] must be False
-    # (and ne[0] True). Only meaningful for the float / complex / array
-    # variants where fill[0] puts NaN at a leaf.
-    if shape == "record_float":
+    if nan_at_zero:
+        # Both records carry NaN at index 0; IEEE ``a == a`` is False.
         assert eq_jit[0].new().value is False
         assert ne_jit[0].new().value is True
 

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -1600,7 +1600,7 @@ def test_auto(v):
             # print(type(expr).__name__, method)
             val1 = getattr(expected, method)(expected).new()
             if method in {"__or__", "__ror__"} and type(expr) is VectorEwiseMultExpr:
-                # Doing e.g. `plus(x & y | z)` isn't allowed--make user be explicit
+                # Doing e.g. `plus(x & y | z)` isn't allowed; make user be explicit
                 with pytest.raises(TypeError):
                     val2 = getattr(expected, method)(expr)
                 with pytest.raises(TypeError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,13 @@ filterwarnings = [
   # this path wrap with ``pytest.warns(NoJITWarning, match="without JIT")``
   # (or ``UserWarning``, which still matches via inheritance).
   "ignore:UDT operator running without JIT:UserWarning",
+
+  # ``pytest -n`` (xdist) makes pytest-benchmark issue this warning during
+  # ``pytest_configure`` to say it disabled itself. Our ``error`` filter
+  # turns warnings into errors, which crashes config before tests run.
+  # Match by message only: naming the category would make pytest import
+  # pytest_benchmark to resolve it, which fails where it isn't installed.
+  "ignore:Benchmarks are automatically disabled:",
 ]
 
 [tool.coverage.run]
@@ -257,7 +264,7 @@ select = [
   "Q",   # flake8-quotes
   "RSE", # flake8-raise
   "RET", # flake8-return
-  # "SLF",  # flake8-self (We can use our own private variables--sheesh!)
+  # "SLF",  # flake8-self (we can use our own private variables, sheesh!)
   "SIM", # flake8-simplify
   # "TID",  # flake8-tidy-imports (Rely on isort and our own judgement)
   # "TCH",  # flake8-type-checking (Note: figure out type checking later)
@@ -312,7 +319,7 @@ ignore = [
   "D400",    # First line should end with a period (Note: prefer D415, which also allows "?" and "!")
   "N801",    # Class name ... should use CapWords convention (Note:we have a few exceptions to this)
   "N802",    # Function name ... should be lowercase
-  "N803",    # Argument name ... should be lowercase (Maybe okay--except in tests)
+  "N803",    # Argument name ... should be lowercase (Maybe okay; except in tests)
   "N806",    # Variable ... in function should be lowercase
   "N807",    # Function name should not start and end with `__`
   "N818",    # Exception name ... should be named with an Error suffix (Note: good advice)
@@ -351,7 +358,7 @@ ignore = [
   "EM",  # flake8-errmsg (Perhaps nicer, but too much work)
   "ICN", # flake8-import-conventions (Doesn't allow "_" prefix such as `_np`)
   "PYI", # flake8-pyi (We don't have stub files yet)
-  "SLF", # flake8-self (We can use our own private variables--sheesh!)
+  "SLF", # flake8-self (we can use our own private variables, sheesh!)
   "TID", # flake8-tidy-imports (Rely on isort and our own judgement)
   "TCH", # flake8-type-checking (Note: figure out type checking later)
   "ARG", # flake8-unused-arguments (Sometimes helpful, but too strict)


### PR DESCRIPTION
## Summary

This commit is a broad maintenance and reliability update focused on UDTs, operator serialization, and SuiteSparse JIT behavior.

- Refactors UDT operator compilation and lifetime management, including shared UDT compile/finalize paths, proper freeing of dynamically created GraphBLAS operator handles, and cleaner JIT metadata handling across unary, binary, index unary, select, monoid, semiring, and aggregator code.
- Improves UDT correctness and compatibility by fixing nested dtype serialization and round-tripping, adding stricter shape checks for binary UDT pairs, improving deserialization of serialized matrix and vector dtypes, and handling BOOL versus INT8 conversion issues in Numba-backed UDT compilation.
- Expands pickle support for user-defined and parameterized operators, with stronger coverage for registered ops, bound index-binary ops, array-UDT theta values, and related scalar and operator behavior.
- Hardens SuiteSparse JIT configuration and test stability, including better compiler-path repair, architecture flag cleanup, more targeted no-JIT warnings, xdist-safe cache and test seeding, and deterministic repr formatting in tests.
- Updates project tooling and docs by tightening CI install behavior, adding new pre-commit checks, refreshing dependency and config files, and modernizing several documentation pages and formatting details.

## Validation

The commit also adds and updates substantial test coverage around dtype serialization, pickling, index-binary behavior, scalar handling, formatting stability, and SSJIT behavior, helping lock in the regression fixes above.